### PR TITLE
Sprint 03: GStreamer topology workflow hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,10 @@ Keep these rules in mind even if you only skim this file:
 - Work in thin slices with one coherent user-visible outcome.
 - For every substantial feature or workflow change, run the expert subagent loop:
   `planner -> developer -> designer -> QA`.
+- Use stable user-facing subagent aliases during sprint work:
+  `Atlas` for planning, `Forge` for development, `Loom` for design, and
+  `Beacon` for QA. The coordinator routes user requests to the matching role
+  even if the underlying subagent session ID changes.
 - Build and verify the current slice end to end before starting adjacent work.
 - Prefer partial success plus diagnostics over hard failure.
 - Preserve source-span mapping whenever parsing, graph IR, selection, or

--- a/docs/PROCESS_POLICY.md
+++ b/docs/PROCESS_POLICY.md
@@ -13,6 +13,10 @@ Read this file before starting feature work.
   `docs/REPOSITORY_STRUCTURE.md`, `docs/TECH_SPIKES.md`.
 - For every substantial feature or workflow change, use the expert subagent
   loop: `planner -> developer -> designer -> QA`.
+- For sprint-based feature work, create or update GitHub Issues and add them to
+  the GitHub Sprint Board before implementation starts. Each issue should name
+  the planner/developer/designer/QA responsibilities, acceptance criteria, and
+  verification checklist.
 - Prefer fixture-driven development when possible.
 - Prefer partial success plus diagnostics over hard failure.
 - Preserve source-span mapping whenever parsing, graph IR, selection, or
@@ -20,10 +24,85 @@ Read this file before starting feature work.
 - Do not declare a feature complete if the user-visible flow is still
   unverified.
 
+## Sprint Board And Branch Workflow
+
+Use GitHub as the sprint source of truth before substantial implementation.
+
+Sprint setup:
+- Create or update a GitHub Project view named after the active sprint, such as
+  `Sprint 03`.
+- If the GitHub API/CLI cannot create or rename Project views, record the
+  desired view name in the handoff and ask the user to rename it in the GitHub
+  web UI.
+- Create one GitHub Issue per independently testable feature or bug.
+- Write issue titles and descriptions in Korean by default.
+- Use English only for code identifiers, commands, file paths, APIs, and
+  GStreamer syntax.
+- Each issue must include planner/developer/designer/QA responsibilities,
+  acceptance criteria, and verification items.
+- Each feature issue should include its own `사용자 QA 체크리스트` section.
+  Avoid creating a separate checklist-only issue unless the user explicitly
+  asks for an aggregate checklist.
+- Expert QA results must be posted back to the corresponding feature issue as a
+  Korean comment before handing the feature to the user.
+- Add sprint labels such as `sprint-03` and role labels such as
+  `role:developer`, `role:designer`, and `role:qa`.
+
+Branch workflow:
+- Start every sprint from a dedicated branch, preferably zero-padded for sort
+  order, such as `sprint_03`.
+- Do not implement sprint work directly on `main`.
+- Keep the sprint branch open until implementation, automated checks,
+  subagent QA, and user QA are complete.
+- Open a GitHub Pull Request after user QA passes.
+- Merge to `main` only after the PR reflects the completed sprint scope and
+  any remaining unverified areas are explicitly documented.
+
+Sprint closeout:
+- Move completed issues to `Done` only after code is committed, pushed, and the
+  user-visible QA path has passed.
+- The user is expected to inspect `In Progress` issues in the active sprint
+  view, run the checklist in each issue, move passing issues to `Done`, and
+  leave comments on issues that fail.
+- After user QA, review the user's comments and classify each finding as either
+  same-sprint rework or next-sprint backlog.
+- Same-sprint rework should be fixed on the active sprint branch and returned
+  to the user for another QA pass.
+- Next-sprint backlog should be captured as a new issue or moved into the next
+  sprint view.
+- If an issue is only partially implemented, leave it `In Progress` or move the
+  remaining work into the next sprint issue.
+- If a bug is discovered during user QA, create or move a follow-up issue into
+  the next sprint view, such as `Sprint 04`.
+
 ## Required Expert Subagent Loop
 
 For every substantial feature request, create or reuse expert subagents for the
 roles below.
+
+### Team Alias Protocol
+
+Use stable user-facing aliases for the expert loop so the user can address a
+role directly during sprint work.
+
+Default aliases:
+- `Atlas`: planner
+- `Forge`: developer
+- `Loom`: designer
+- `Beacon`: QA
+
+Alias rules:
+- Treat aliases as role contracts, not permanent process IDs. The underlying
+  subagent nickname or session ID may change between runs.
+- If the user says "Ask Beacon" or gives work to one alias, route that request
+  to the matching role. Reuse a live matching subagent when available; otherwise
+  spawn a new one with the same alias in its prompt.
+- Record each alias's output in the relevant GitHub Issue when it affects
+  sprint scope, implementation, design, or verification.
+- The coordinating agent remains responsible for integration, final judgement,
+  and explaining verified versus unverified work.
+- If the user criticizes or redirects an alias, preserve the useful signal and
+  feed it back into the next loop without defensiveness.
 
 ### Planner
 
@@ -91,12 +170,14 @@ QA output format:
 Use this loop for feature delivery:
 
 1. Read `AGENTS.md` and this document.
-2. Have the planner define the smallest useful slice.
-3. Have the developer implement that slice.
-4. Have the designer review the interaction and visual result.
-5. Have QA verify the actual user-visible behavior.
-6. If QA finds issues, return the findings to the developer and repeat the loop.
-7. The coordinating agent summarizes the final state only after QA evidence is
+2. Create or update the GitHub Sprint Board items for the slice.
+3. Have the planner define the smallest useful slice.
+4. Have the developer implement that slice.
+5. Have the designer review the interaction and visual result.
+6. Have QA verify the actual user-visible behavior.
+7. If QA finds issues, return the findings to the developer and repeat the loop.
+8. Provide the user-facing unit test checklist before asking the user to test.
+9. The coordinating agent summarizes the final state only after QA evidence is
    present.
 
 Do not skip the QA step for feature work.

--- a/docs/SPRINT_03_WEEK2.md
+++ b/docs/SPRINT_03_WEEK2.md
@@ -1,0 +1,129 @@
+# Sprint 03 Week 2 Handoff
+
+Date: 2026-04-26
+
+## Goal
+
+Implement the Week 2 MVP slice for linked pipeline analysis:
+
+- Use local GStreamer metadata when available.
+- Keep topology rendering working when GStreamer is unavailable.
+- Show loaded pipeline text from the workspace.
+- Highlight the selected element's source span.
+- Allow view-only node repositioning while preserving edges.
+- Surface parser diagnostics as a generation warning.
+- Add a first-pass remote OE-Linux connection/load path.
+
+## Implemented Scope
+
+### Local GStreamer Metadata
+
+- Added backend commands:
+  - `probe_local_gstreamer`
+  - `inspect_local_element`
+- Local metadata uses `gst-inspect-1.0` if installed.
+- Inspector now shows runtime metadata for the selected element:
+  - authority
+  - plugin name
+  - long name
+  - klass
+  - description
+  - pad templates
+  - GStreamer properties
+- If `gst-inspect-1.0` is missing or an element cannot be inspected, topology
+  still renders and the inspector falls back to parsed text.
+
+### Pipeline Source Viewer
+
+- Added a collapsible `Pipeline 원문` panel in the workspace.
+- The view model now preserves full `normalizedText`.
+- Node source spans now preserve byte offsets plus line ranges.
+- Selecting a node highlights the corresponding normalized pipeline text span.
+
+### Canvas Node Movement
+
+- React Flow nodes are now draggable through a dedicated node grip.
+- Dragging only changes visual position.
+- Edges remain connected to the same source/target nodes.
+- Manual positions are persisted in `localStorage` by document/graph signature.
+- Added layout reset control.
+
+### Syntax Diagnostic Alert
+
+- If parser diagnostics include warning/error severity, the workspace shows a
+  non-blocking syntax alert after topology generation.
+- Diagnostics panel and source panel remain available for deeper review.
+
+### Remote OE-Linux First Pass
+
+- Added home-screen fields for:
+  - IP
+  - port
+  - user ID
+  - password
+  - remote pipeline path
+- Added actions:
+  - remote connection probe
+  - remote topology generation through existing SFTP load
+- Added backend command:
+  - `inspect_remote_element`
+- Remote metadata uses read-only SSH command execution with `gst-inspect-1.0`.
+- Credentials are kept only in React memory for this MVP slice.
+
+## Parser Hardening Included
+
+Week 2 source linking depends on source spans, so the previous sample parser
+gaps were fixed as part of this slice:
+
+- `02_videotestsrc_tee_branch.pld`
+  - `tee name=t t.` and later `t.` are parsed as branch references.
+  - `t.` is no longer reported as a loose element token.
+- `04_compositor_named_pad.pld`
+  - `compositor name=mix` remains visible.
+  - `mix.` and `mix.sink_1` resolve to the compositor instead of fake nodes.
+
+## Verified
+
+- `npm run lint`
+- `npm run build`
+- `cd src-tauri && cargo test`
+- `command -v gst-inspect-1.0`
+  - local command exists at `/Users/jshong/anaconda3/bin/gst-inspect-1.0`
+- `gst-inspect-1.0 videotestsrc`
+  - command succeeded and returned factory/property/pad-template output
+- `npm run tauri:dev`
+  - native process confirmed:
+    `/Users/jshong/Downloads/Code/gstreamer-to-topology/src-tauri/target/debug/gstreamer-to-topology`
+
+## Unverified
+
+- Real remote `OE-Linux` target verification is still unverified.
+- Specifically unverified:
+  - SSH authentication against an actual target
+  - SFTP remote file read against an actual target
+  - remote `gst-inspect-1.0` metadata parsing against an actual target
+  - failed-auth UX against an actual target
+- Manual visual QA in the native window should still be performed by the user
+  because this environment confirmed the process but did not record an
+  interactive visual walkthrough.
+
+## Remaining Risks
+
+- `gst-inspect-1.0` output is human-readable and can vary by version/plugin.
+  The current parser is intentionally heuristic.
+- Local metadata lookup has no explicit timeout/output-size cap yet.
+- Remote metadata reconnects per selected element in this first pass.
+- Source highlighting targets normalized text, not original RTF byte positions.
+- Manual layout persistence is local-only and can be reset, but is not yet part
+  of an explicit saved workspace model.
+
+## Next Smallest Step
+
+Run manual QA in the native app:
+
+1. Open fixtures `01` to `04`.
+2. Confirm fixture `02` branch and fixture `04` compositor rendering.
+3. Click nodes and open `Pipeline 원문`.
+4. Drag nodes with the grip and verify edges stay connected.
+5. Inspect `videotestsrc` metadata on a local GStreamer-enabled machine.
+6. Test remote probe/load with a real `OE-Linux` target.

--- a/src-tauri/src/commands/pipeline.rs
+++ b/src-tauri/src/commands/pipeline.rs
@@ -2,11 +2,14 @@ use std::fs;
 use std::io::Read;
 use std::net::TcpStream;
 use std::path::Path;
+use std::process::Command;
 
 use ssh2::Session;
 
 use crate::models::{
-    NormalizationResult, PipelineDocument, RemoteProbeResponse, RemoteTargetRequest, SourceKind,
+    ElementMetadataResponse, ElementPadTemplateMetadata, ElementPropertyMetadata,
+    GStreamerProbeResponse, MetadataAuthority, NormalizationResult, PipelineDocument,
+    RemoteProbeResponse, RemoteTargetRequest, SourceKind,
 };
 use crate::parser::{normalize_text, parse_document};
 
@@ -50,6 +53,67 @@ pub fn load_local_pipeline_file(path: String) -> Result<PipelineDocument, String
 }
 
 #[tauri::command]
+pub fn probe_local_gstreamer() -> GStreamerProbeResponse {
+    match Command::new("gst-inspect-1.0").arg("--version").output() {
+        Ok(output) if output.status.success() => GStreamerProbeResponse {
+            available: true,
+            authority: MetadataAuthority::Local,
+            version_output: Some(String::from_utf8_lossy(&output.stdout).trim().to_string()),
+            diagnostic: None,
+        },
+        Ok(output) => GStreamerProbeResponse {
+            available: false,
+            authority: MetadataAuthority::Local,
+            version_output: None,
+            diagnostic: Some(
+                String::from_utf8_lossy(&output.stderr)
+                    .trim()
+                    .to_string()
+                    .if_empty("gst-inspect-1.0 --version command failed."),
+            ),
+        },
+        Err(error) => GStreamerProbeResponse {
+            available: false,
+            authority: MetadataAuthority::Local,
+            version_output: None,
+            diagnostic: Some(format!("gst-inspect-1.0 is not available: {error}")),
+        },
+    }
+}
+
+#[tauri::command]
+pub fn inspect_local_element(factory_name: String) -> ElementMetadataResponse {
+    let factory_name = factory_name.trim().to_string();
+    if factory_name.is_empty() {
+        return unavailable_element_metadata(
+            MetadataAuthority::Local,
+            factory_name,
+            "Element factory name is empty.",
+        );
+    }
+
+    match Command::new("gst-inspect-1.0").arg(&factory_name).output() {
+        Ok(output) if output.status.success() => {
+            let raw_output = String::from_utf8_lossy(&output.stdout).into_owned();
+            parse_gst_inspect_output(MetadataAuthority::Local, factory_name, raw_output)
+        }
+        Ok(output) => unavailable_element_metadata(
+            MetadataAuthority::Local,
+            factory_name,
+            String::from_utf8_lossy(&output.stderr)
+                .trim()
+                .to_string()
+                .if_empty("gst-inspect-1.0 could not inspect this element."),
+        ),
+        Err(error) => unavailable_element_metadata(
+            MetadataAuthority::Local,
+            factory_name,
+            format!("gst-inspect-1.0 is not available: {error}"),
+        ),
+    }
+}
+
+#[tauri::command]
 pub fn probe_remote_target(
     request: RemoteTargetRequest,
     sample_element: Option<String>,
@@ -71,6 +135,38 @@ pub fn probe_remote_target(
         version_output,
         sample_element_output,
     })
+}
+
+#[tauri::command]
+pub fn inspect_remote_element(
+    request: RemoteTargetRequest,
+    factory_name: String,
+) -> Result<ElementMetadataResponse, String> {
+    let factory_name = factory_name.trim().to_string();
+    if factory_name.is_empty() {
+        return Ok(unavailable_element_metadata(
+            MetadataAuthority::Remote,
+            factory_name,
+            "Element factory name is empty.",
+        ));
+    }
+
+    let mut session = connect_remote(&request)?;
+    match exec_remote_command(
+        &mut session,
+        &format!("gst-inspect-1.0 {}", shell_escape(&factory_name)),
+    ) {
+        Ok(raw_output) => Ok(parse_gst_inspect_output(
+            MetadataAuthority::Remote,
+            factory_name,
+            raw_output,
+        )),
+        Err(error) => Ok(unavailable_element_metadata(
+            MetadataAuthority::Remote,
+            factory_name,
+            error,
+        )),
+    }
 }
 
 #[tauri::command]
@@ -161,4 +257,176 @@ fn exec_remote_command(session: &mut Session, command: &str) -> Result<String, S
 
 fn shell_escape(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn unavailable_element_metadata(
+    authority: MetadataAuthority,
+    factory_name: String,
+    diagnostic: impl Into<String>,
+) -> ElementMetadataResponse {
+    ElementMetadataResponse {
+        available: false,
+        authority,
+        factory_name,
+        long_name: None,
+        klass: None,
+        description: None,
+        plugin_name: None,
+        properties: Vec::new(),
+        pad_templates: Vec::new(),
+        raw_output: None,
+        diagnostic: Some(diagnostic.into()),
+    }
+}
+
+fn parse_gst_inspect_output(
+    authority: MetadataAuthority,
+    factory_name: String,
+    raw_output: String,
+) -> ElementMetadataResponse {
+    let mut metadata = ElementMetadataResponse {
+        available: true,
+        authority,
+        factory_name,
+        long_name: None,
+        klass: None,
+        description: None,
+        plugin_name: None,
+        properties: Vec::new(),
+        pad_templates: Vec::new(),
+        raw_output: Some(raw_output.clone()),
+        diagnostic: None,
+    };
+    let mut section = "";
+    let mut current_pad: Option<ElementPadTemplateMetadata> = None;
+
+    for line in raw_output.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        match trimmed {
+            "Factory Details:" => {
+                flush_pad_template(&mut metadata.pad_templates, &mut current_pad);
+                section = "factory";
+                continue;
+            }
+            "Plugin Details:" => {
+                flush_pad_template(&mut metadata.pad_templates, &mut current_pad);
+                section = "plugin";
+                continue;
+            }
+            "Pad Templates:" => {
+                section = "pads";
+                continue;
+            }
+            "Element Properties:" => {
+                flush_pad_template(&mut metadata.pad_templates, &mut current_pad);
+                section = "properties";
+                continue;
+            }
+            _ => {}
+        }
+
+        match section {
+            "factory" => {
+                if let Some(value) = parse_gst_field(trimmed, "Long-name") {
+                    metadata.long_name = Some(value);
+                } else if let Some(value) = parse_gst_field(trimmed, "Klass") {
+                    metadata.klass = Some(value);
+                } else if let Some(value) = parse_gst_field(trimmed, "Description") {
+                    metadata.description.get_or_insert(value);
+                }
+            }
+            "plugin" => {
+                if let Some(value) = parse_gst_field(trimmed, "Name") {
+                    metadata.plugin_name.get_or_insert(value);
+                } else if let Some(value) = parse_gst_field(trimmed, "Description") {
+                    metadata.description.get_or_insert(value);
+                }
+            }
+            "pads" => {
+                if let Some((direction, name)) = parse_pad_template_heading(trimmed) {
+                    flush_pad_template(&mut metadata.pad_templates, &mut current_pad);
+                    current_pad = Some(ElementPadTemplateMetadata {
+                        direction,
+                        name,
+                        presence: None,
+                    });
+                } else if let Some(value) = parse_gst_field(trimmed, "Availability") {
+                    if let Some(pad) = &mut current_pad {
+                        pad.presence = Some(value);
+                    }
+                }
+            }
+            "properties" => {
+                if let Some(property) = parse_property_line(trimmed) {
+                    metadata.properties.push(property);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    flush_pad_template(&mut metadata.pad_templates, &mut current_pad);
+    metadata
+}
+
+fn parse_gst_field(line: &str, field: &str) -> Option<String> {
+    line.strip_prefix(field)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn parse_pad_template_heading(line: &str) -> Option<(String, String)> {
+    let (direction, rest) = line.split_once(" template: ")?;
+    let name = rest.trim().trim_matches('\'').to_string();
+    if direction.is_empty() || name.is_empty() {
+        return None;
+    }
+
+    Some((direction.to_string(), name))
+}
+
+fn parse_property_line(line: &str) -> Option<ElementPropertyMetadata> {
+    let (name, description) = line.split_once(':')?;
+    let name = name.trim();
+
+    if name.is_empty()
+        || name.contains(char::is_whitespace)
+        || matches!(name, "flags" | "Enum" | "Default")
+    {
+        return None;
+    }
+
+    Some(ElementPropertyMetadata {
+        name: name.to_string(),
+        description: Some(description.trim().to_string()).filter(|value| !value.is_empty()),
+    })
+}
+
+fn flush_pad_template(
+    pad_templates: &mut Vec<ElementPadTemplateMetadata>,
+    current_pad: &mut Option<ElementPadTemplateMetadata>,
+) {
+    if let Some(pad) = current_pad.take() {
+        pad_templates.push(pad);
+    }
+}
+
+trait EmptyStringFallback {
+    fn if_empty(self, fallback: &str) -> String;
+}
+
+impl EmptyStringFallback for String {
+    fn if_empty(self, fallback: &str) -> String {
+        if self.is_empty() {
+            fallback.to_string()
+        } else {
+            self
+        }
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,8 +6,11 @@ pub fn run() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             commands::pipeline::load_local_pipeline_file,
+            commands::pipeline::inspect_local_element,
+            commands::pipeline::inspect_remote_element,
             commands::pipeline::normalize_rtf_text,
             commands::pipeline::parse_pipeline_text,
+            commands::pipeline::probe_local_gstreamer,
             commands::pipeline::probe_remote_target,
             commands::pipeline::load_remote_pipeline
         ])

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -1,7 +1,9 @@
 pub mod pipeline;
 
 pub use pipeline::{
-    DiagnosticSeverity, NormalizationResult, ParseDiagnostic, PipelineDocument, PipelineEdge,
-    PipelineGraph, PipelineNode, PipelineNodeKind, PipelinePort, PipelinePortKind,
-    PipelineProperty, RemoteProbeResponse, RemoteTargetRequest, SourceKind, SourceSpan,
+    DiagnosticSeverity, ElementMetadataResponse, ElementPadTemplateMetadata,
+    ElementPropertyMetadata, GStreamerProbeResponse, MetadataAuthority, NormalizationResult,
+    ParseDiagnostic, PipelineDocument, PipelineEdge, PipelineGraph, PipelineNode, PipelineNodeKind,
+    PipelinePort, PipelinePortKind, PipelineProperty, RemoteProbeResponse, RemoteTargetRequest,
+    SourceKind, SourceSpan,
 };

--- a/src-tauri/src/models/pipeline.rs
+++ b/src-tauri/src/models/pipeline.rs
@@ -148,3 +148,46 @@ pub struct RemoteProbeResponse {
     pub version_output: String,
     pub sample_element_output: Option<String>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataAuthority {
+    Local,
+    Remote,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GStreamerProbeResponse {
+    pub available: bool,
+    pub authority: MetadataAuthority,
+    pub version_output: Option<String>,
+    pub diagnostic: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ElementPropertyMetadata {
+    pub name: String,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ElementPadTemplateMetadata {
+    pub name: String,
+    pub direction: String,
+    pub presence: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ElementMetadataResponse {
+    pub available: bool,
+    pub authority: MetadataAuthority,
+    pub factory_name: String,
+    pub long_name: Option<String>,
+    pub klass: Option<String>,
+    pub description: Option<String>,
+    pub plugin_name: Option<String>,
+    pub properties: Vec<ElementPropertyMetadata>,
+    pub pad_templates: Vec<ElementPadTemplateMetadata>,
+    pub raw_output: Option<String>,
+    pub diagnostic: Option<String>,
+}

--- a/src-tauri/src/parser/pipeline.rs
+++ b/src-tauri/src/parser/pipeline.rs
@@ -10,6 +10,7 @@ enum ChainItem {
     Node(NodeEndpoint),
     Reference(ReferenceEndpoint),
     Caps(CapsSegment),
+    Break,
 }
 
 #[derive(Debug, Clone)]
@@ -51,6 +52,8 @@ struct ParsedElement {
     instance_name: Option<String>,
     properties: Vec<PipelineProperty>,
     loose_tokens: Vec<String>,
+    source_span: SourceSpan,
+    trailing_references: Vec<ReferenceEndpoint>,
 }
 
 pub fn parse_document(
@@ -89,65 +92,14 @@ pub fn parse_graph(normalized_text: &str) -> (PipelineGraph, Vec<ParseDiagnostic
                 continue;
             }
 
-            if let Some(reference) = parse_reference_component(component.1, component.0.clone()) {
-                items.push(ChainItem::Reference(reference));
-                continue;
-            }
-
-            if let Some(caps) = parse_caps_component(component.1, component.0.clone()) {
-                items.push(ChainItem::Caps(caps));
-                continue;
-            }
-
-            match parse_element_component(component.1) {
-                Some(element) => {
-                    let node_id = format!("node-{}", graph.nodes.len());
-                    if let Some(instance_name) = &element.instance_name {
-                        if instance_map
-                            .insert(instance_name.clone(), node_id.clone())
-                            .is_some()
-                        {
-                            diagnostics.push(ParseDiagnostic::warning(
-                                "duplicate-instance-name",
-                                format!(
-                                    "The named element `{instance_name}` was declared more than once."
-                                ),
-                                Some(component.0.clone()),
-                            ));
-                        }
-                    }
-
-                    if !element.loose_tokens.is_empty() {
-                        diagnostics.push(ParseDiagnostic::warning(
-                            "unparsed-element-token",
-                            format!(
-                                "Ignored tokens on element `{}`: {}",
-                                element.factory_name,
-                                element.loose_tokens.join(", ")
-                            ),
-                            Some(component.0.clone()),
-                        ));
-                    }
-
-                    graph.nodes.push(PipelineNode {
-                        id: node_id.clone(),
-                        factory_name: element.factory_name,
-                        instance_name: element.instance_name,
-                        kind: PipelineNodeKind::Element,
-                        properties: element.properties,
-                        source_span: component.0.clone(),
-                    });
-                    items.push(ChainItem::Node(NodeEndpoint {
-                        node_id,
-                        span: component.0,
-                    }));
-                }
-                None => diagnostics.push(ParseDiagnostic::warning(
-                    "empty-component",
-                    "Encountered an empty pipeline component.",
-                    Some(component.0),
-                )),
-            }
+            let component_items = parse_component_items(
+                component.1,
+                component.0,
+                &mut graph,
+                &mut instance_map,
+                &mut diagnostics,
+            );
+            items.extend(component_items);
         }
 
         pending_edges.extend(build_pending_edges(items, &mut diagnostics));
@@ -287,16 +239,95 @@ fn parse_caps_component(text: &str, span: SourceSpan) -> Option<CapsSegment> {
     })
 }
 
-fn parse_element_component(text: &str) -> Option<ParsedElement> {
-    let tokens = split_whitespace_tokens(text);
-    let (factory_span, factory_name) = tokens.first()?.clone();
-    let _ = factory_span;
+fn parse_component_items(
+    text: &str,
+    component_span: SourceSpan,
+    graph: &mut PipelineGraph,
+    instance_map: &mut HashMap<String, String>,
+    diagnostics: &mut Vec<ParseDiagnostic>,
+) -> Vec<ChainItem> {
+    if let Some(reference) = parse_reference_component(text, component_span.clone()) {
+        return vec![ChainItem::Reference(reference)];
+    }
 
+    if let Some(caps) = parse_caps_component(text, component_span.clone()) {
+        return vec![ChainItem::Caps(caps)];
+    }
+
+    let tokens = split_whitespace_tokens(text, component_span.start);
+    let mut items = Vec::new();
+    let mut index = 0usize;
+
+    while index < tokens.len() {
+        let (token_span, token) = tokens[index].clone();
+
+        if let Some(reference) = parse_reference_component(&token, token_span.clone()) {
+            items.push(ChainItem::Reference(reference));
+            index += 1;
+            if index < tokens.len() {
+                items.push(ChainItem::Break);
+            }
+            continue;
+        }
+
+        if let Some(caps) = parse_caps_component(&token, token_span) {
+            items.push(ChainItem::Caps(caps));
+            index += 1;
+            continue;
+        }
+
+        let (element, next_index) = parse_element_tokens(&tokens, index);
+        index = next_index;
+        let element_span = element.source_span.clone();
+        let trailing_references = element.trailing_references.clone();
+        let node_id = push_element_node(
+            graph,
+            instance_map,
+            diagnostics,
+            component_span.clone(),
+            element,
+        );
+
+        items.push(ChainItem::Node(NodeEndpoint {
+            node_id,
+            span: element_span,
+        }));
+
+        for reference in trailing_references {
+            items.push(ChainItem::Break);
+            items.push(ChainItem::Reference(reference));
+        }
+
+        if index < tokens.len() && !matches!(items.last(), Some(ChainItem::Break)) {
+            items.push(ChainItem::Break);
+        }
+    }
+
+    if items.is_empty() {
+        diagnostics.push(ParseDiagnostic::warning(
+            "empty-component",
+            "Encountered an empty pipeline component.",
+            Some(component_span),
+        ));
+    }
+
+    items
+}
+
+fn parse_element_tokens(
+    tokens: &[(SourceSpan, String)],
+    start_index: usize,
+) -> (ParsedElement, usize) {
+    let (factory_span, factory_name) = tokens[start_index].clone();
     let mut properties = Vec::new();
     let mut loose_tokens = Vec::new();
     let mut instance_name = None;
+    let mut source_span = factory_span.clone();
+    let mut trailing_references = Vec::new();
+    let mut index = start_index + 1;
 
-    for (_, token) in tokens.into_iter().skip(1) {
+    while index < tokens.len() {
+        let (token_span, token) = tokens[index].clone();
         if let Some((key, value)) = token.split_once('=') {
             let property = PipelineProperty {
                 key: key.to_string(),
@@ -305,21 +336,87 @@ fn parse_element_component(text: &str) -> Option<ParsedElement> {
             if property.key == "name" {
                 instance_name = Some(property.value.clone());
             }
+            source_span = source_span.merge(&token_span);
             properties.push(property);
-        } else {
+            index += 1;
+            continue;
+        }
+
+        if let Some(reference) = parse_reference_component(&token, token_span) {
+            trailing_references.push(reference);
+            index += 1;
+            continue;
+        }
+
+        if token.contains("::") {
             loose_tokens.push(token);
+            source_span = source_span.merge(&tokens[index].0);
+            index += 1;
+            continue;
+        }
+
+        break;
+    }
+
+    (
+        ParsedElement {
+            factory_name,
+            instance_name,
+            properties,
+            loose_tokens,
+            source_span,
+            trailing_references,
+        },
+        index,
+    )
+}
+
+fn push_element_node(
+    graph: &mut PipelineGraph,
+    instance_map: &mut HashMap<String, String>,
+    diagnostics: &mut Vec<ParseDiagnostic>,
+    component_span: SourceSpan,
+    element: ParsedElement,
+) -> String {
+    let node_id = format!("node-{}", graph.nodes.len());
+    if let Some(instance_name) = &element.instance_name {
+        if instance_map
+            .insert(instance_name.clone(), node_id.clone())
+            .is_some()
+        {
+            diagnostics.push(ParseDiagnostic::warning(
+                "duplicate-instance-name",
+                format!("The named element `{instance_name}` was declared more than once."),
+                Some(component_span.clone()),
+            ));
         }
     }
 
-    Some(ParsedElement {
-        factory_name,
-        instance_name,
-        properties,
-        loose_tokens,
-    })
+    if !element.loose_tokens.is_empty() {
+        diagnostics.push(ParseDiagnostic::warning(
+            "unparsed-element-token",
+            format!(
+                "Ignored tokens on element `{}`: {}",
+                element.factory_name,
+                element.loose_tokens.join(", ")
+            ),
+            Some(component_span),
+        ));
+    }
+
+    graph.nodes.push(PipelineNode {
+        id: node_id.clone(),
+        factory_name: element.factory_name,
+        instance_name: element.instance_name,
+        kind: PipelineNodeKind::Element,
+        properties: element.properties,
+        source_span: element.source_span,
+    });
+
+    node_id
 }
 
-fn split_whitespace_tokens(text: &str) -> Vec<(SourceSpan, String)> {
+fn split_whitespace_tokens(text: &str, base_offset: usize) -> Vec<(SourceSpan, String)> {
     let mut tokens = Vec::new();
     let mut token_start = None;
     let mut in_quotes = false;
@@ -359,7 +456,7 @@ fn split_whitespace_tokens(text: &str) -> Vec<(SourceSpan, String)> {
             {
                 if let Some(start) = token_start.take() {
                     tokens.push((
-                        SourceSpan::new(start, index),
+                        SourceSpan::new(base_offset + start, base_offset + index),
                         text[start..index].to_string(),
                     ));
                 }
@@ -372,7 +469,7 @@ fn split_whitespace_tokens(text: &str) -> Vec<(SourceSpan, String)> {
 
     if let Some(start) = token_start {
         tokens.push((
-            SourceSpan::new(start, text.len()),
+            SourceSpan::new(base_offset + start, base_offset + text.len()),
             text[start..].to_string(),
         ));
     }
@@ -417,6 +514,11 @@ fn build_pending_edges(
                     pending_edges.push(edge);
                 }
                 previous = Some(endpoint);
+                caps.clear();
+                caps_span = None;
+            }
+            ChainItem::Break => {
+                previous = None;
                 caps.clear();
                 caps_span = None;
             }
@@ -579,6 +681,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::parse_graph;
+    use crate::models::PipelinePortKind;
     use crate::parser::normalize_text;
 
     fn repo_root() -> PathBuf {
@@ -634,6 +737,112 @@ mod tests {
                     .all(|diagnostic| diagnostic.code != "panic"),
                 "parser should report warnings, not crash, for sample {sample_name}"
             );
+            assert!(
+                graph.edges.iter().any(|edge| {
+                    edge.source_port.as_ref().is_some_and(|port| {
+                        matches!(port.port_kind, PipelinePortKind::Named)
+                            && port.port_name.starts_with("src_")
+                    })
+                }),
+                "expected named source pads such as src_1 from sample {sample_name}"
+            );
         }
+    }
+
+    #[test]
+    fn parses_tee_inline_references_as_branches() {
+        let sample_path = repo_root().join("fixtures/pipelines/02_videotestsrc_tee_branch.pld");
+        let raw = fs::read_to_string(sample_path).expect("sample fixture should exist");
+        let normalized = normalize_text(&raw);
+        let (graph, diagnostics) = parse_graph(&normalized.normalized_text);
+        let tee = graph
+            .nodes
+            .iter()
+            .find(|node| node.instance_name.as_deref() == Some("t"))
+            .expect("tee node should exist");
+        let branch_count = graph
+            .edges
+            .iter()
+            .filter(|edge| edge.source_node_id == tee.id)
+            .count();
+
+        assert!(
+            branch_count >= 2,
+            "tee should have multiple outgoing branches"
+        );
+        assert!(
+            diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unparsed-element-token" || !diagnostic.message.contains("t.")
+            }),
+            "inline tee references should not be reported as loose tokens"
+        );
+    }
+
+    #[test]
+    fn parses_compositor_named_pad_fixture() {
+        let sample_path = repo_root().join("fixtures/pipelines/04_compositor_named_pad.pld");
+        let raw = fs::read_to_string(sample_path).expect("sample fixture should exist");
+        let normalized = normalize_text(&raw);
+        let (graph, diagnostics) = parse_graph(&normalized.normalized_text);
+        let compositor = graph
+            .nodes
+            .iter()
+            .find(|node| node.instance_name.as_deref() == Some("mix"))
+            .expect("compositor node should exist");
+        let incoming_count = graph
+            .edges
+            .iter()
+            .filter(|edge| edge.target_node_id == compositor.id)
+            .count();
+        let has_request_pad = graph.edges.iter().any(|edge| {
+            edge.target_node_id == compositor.id
+                && edge.target_port.as_ref().is_some_and(|port| {
+                    matches!(port.port_kind, PipelinePortKind::Request)
+                        && port.port_name == "sink_1"
+                })
+        });
+        let outgoing_count = graph
+            .edges
+            .iter()
+            .filter(|edge| edge.source_node_id == compositor.id)
+            .count();
+        let has_sink_to_source_edge = graph.edges.iter().any(|edge| {
+            let source = graph
+                .nodes
+                .iter()
+                .find(|node| node.id == edge.source_node_id);
+            let target = graph
+                .nodes
+                .iter()
+                .find(|node| node.id == edge.target_node_id);
+
+            source.is_some_and(|node| node.factory_name == "autovideosink")
+                && target.is_some_and(|node| node.factory_name == "videotestsrc")
+        });
+
+        assert_eq!(compositor.factory_name, "compositor");
+        assert_eq!(incoming_count, 2, "compositor should receive two inputs");
+        assert_eq!(outgoing_count, 1, "compositor should have one output chain");
+        assert!(
+            has_request_pad,
+            "mix.sink_1 should remain available as a compositor request pad"
+        );
+        assert!(
+            !has_sink_to_source_edge,
+            "adjacent chains without ! should not create autovideosink -> videotestsrc"
+        );
+        assert!(
+            graph
+                .nodes
+                .iter()
+                .all(|node| node.factory_name != "mix." && node.factory_name != "mix.sink_1"),
+            "named pad references should not become fake element nodes"
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.code != "unresolved-reference"),
+            "named compositor references should resolve"
+        );
     }
 }

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,7 +1,10 @@
 import { useState, type ChangeEvent } from 'react'
 import {
   isTauriRuntime,
+  loadRemotePipeline,
   parsePipelineText,
+  probeRemoteTarget,
+  type RemoteTargetInput,
 } from './backend.ts'
 import { HomeScreen } from '../features/home/HomeScreen.tsx'
 import { WorkspaceShell } from '../features/workspace/WorkspaceShell.tsx'
@@ -11,6 +14,17 @@ import type { PipelineDocumentViewModel } from '../graph/types.ts'
 function AppShell() {
   const [activeDocument, setActiveDocument] = useState<PipelineDocumentViewModel | null>(null)
   const [pipelineText, setPipelineText] = useState('')
+  const [remoteTarget, setRemoteTarget] = useState<RemoteTargetInput>({
+    host: '',
+    port: 22,
+    username: '',
+    password: '',
+  })
+  const [remotePath, setRemotePath] = useState('')
+  const [activeRemoteTarget, setActiveRemoteTarget] = useState<RemoteTargetInput | null>(null)
+  const [remoteStatusMessage, setRemoteStatusMessage] = useState(
+    '원격 OE-Linux 장비가 준비되면 IP, 계정, 경로를 입력해 읽기 전용으로 불러올 수 있습니다.',
+  )
   const [statusMessage, setStatusMessage] = useState(
     '로컬 파이프라인 파일을 열거나 텍스트를 붙여넣어 토폴로지로 변환하세요.',
   )
@@ -27,8 +41,11 @@ function AppShell() {
       const backendDocument = await parsePipelineText(rawText, sourceName)
       const viewModel = await toViewModel(backendDocument)
       setActiveDocument(viewModel)
+      setActiveRemoteTarget(null)
       setStatusMessage(
-        `${sourceName}에서 노드 ${viewModel.graph.nodes.length}개와 엣지 ${viewModel.graph.edges.length}개를 파싱했습니다.`,
+        viewModel.diagnostics.length
+          ? `${sourceName}에서 토폴로지를 생성했습니다. 확인할 파서 진단 ${viewModel.diagnostics.length}건이 있습니다.`
+          : `${sourceName}에서 노드 ${viewModel.graph.nodes.length}개와 엣지 ${viewModel.graph.edges.length}개를 파싱했습니다.`,
       )
     } catch (error) {
       console.error(error)
@@ -58,15 +75,84 @@ function AppShell() {
     await handlePipelineImport(pipelineText, '붙여넣은 파이프라인')
   }
 
+  function sanitizeRemoteTarget(): RemoteTargetInput {
+    return {
+      ...remoteTarget,
+      host: remoteTarget.host.trim(),
+      username: remoteTarget.username.trim(),
+      port: Number(remoteTarget.port || 22),
+    }
+  }
+
+  async function handleProbeRemote() {
+    if (!isTauriRuntime()) {
+      setRemoteStatusMessage('원격 접속은 데스크톱 Tauri 런타임에서만 사용할 수 있습니다.')
+      return
+    }
+
+    const request = sanitizeRemoteTarget()
+    if (!request.host || !request.username || !request.password) {
+      setRemoteStatusMessage('원격 IP, 계정 ID, PW를 모두 입력해 주세요.')
+      return
+    }
+
+    setRemoteStatusMessage(`${request.host} 접속 및 gst-inspect 확인 중...`)
+    try {
+      const response = await probeRemoteTarget(request, 'videotestsrc')
+      setRemoteStatusMessage(
+        `${response.host} 접속 성공. ${response.version_output.split('\n')[0] ?? 'GStreamer 정보를 확인했습니다.'}`,
+      )
+    } catch (error) {
+      console.error(error)
+      setRemoteStatusMessage('원격 접속 또는 gst-inspect 확인에 실패했습니다. IP, 계정, PW, 네트워크를 확인해 주세요.')
+    }
+  }
+
+  async function handleLoadRemotePipeline() {
+    if (!isTauriRuntime()) {
+      setRemoteStatusMessage('원격 파이프라인 불러오기는 데스크톱 Tauri 런타임에서만 사용할 수 있습니다.')
+      return
+    }
+
+    const request = sanitizeRemoteTarget()
+    if (!request.host || !request.username || !request.password || !remotePath.trim()) {
+      setRemoteStatusMessage('원격 IP, 계정 ID, PW, 파이프라인 파일 경로를 모두 입력해 주세요.')
+      return
+    }
+
+    setRemoteStatusMessage(`${request.host}:${remotePath.trim()} 원격 파일을 읽는 중...`)
+    try {
+      const backendDocument = await loadRemotePipeline(request, remotePath.trim())
+      const viewModel = await toViewModel(backendDocument)
+      setActiveDocument(viewModel)
+      setActiveRemoteTarget(request)
+      setRemoteStatusMessage(
+        viewModel.diagnostics.length
+          ? `원격 파이프라인을 열었습니다. 확인할 파서 진단 ${viewModel.diagnostics.length}건이 있습니다.`
+          : `원격 파이프라인을 열었습니다. 노드 ${viewModel.graph.nodes.length}개와 엣지 ${viewModel.graph.edges.length}개를 파싱했습니다.`,
+      )
+    } catch (error) {
+      console.error(error)
+      setRemoteStatusMessage('원격 파이프라인을 불러오지 못했습니다. 파일 경로와 권한을 확인해 주세요.')
+    }
+  }
+
   if (!activeDocument) {
     return (
       <HomeScreen
         isTauri={isTauriRuntime()}
         pipelineText={pipelineText}
         statusMessage={statusMessage}
+        remotePath={remotePath}
+        remoteStatusMessage={remoteStatusMessage}
+        remoteTarget={remoteTarget}
         onFileSelected={handleFileSelected}
+        onLoadRemotePipeline={handleLoadRemotePipeline}
         onParseText={handleParsePastedText}
         onPipelineTextChange={setPipelineText}
+        onProbeRemote={handleProbeRemote}
+        onRemotePathChange={setRemotePath}
+        onRemoteTargetChange={setRemoteTarget}
       />
     )
   }
@@ -75,6 +161,7 @@ function AppShell() {
     <WorkspaceShell
       key={activeDocument.id}
       document={activeDocument}
+      remoteTarget={activeRemoteTarget}
       onBackHome={() => setActiveDocument(null)}
     />
   )

--- a/src/app/backend.ts
+++ b/src/app/backend.ts
@@ -80,6 +80,40 @@ export type RemoteProbeResponse = {
   sample_element_output?: string | null
 }
 
+type MetadataAuthority = 'local' | 'remote'
+
+export type GStreamerProbeResponse = {
+  available: boolean
+  authority: MetadataAuthority
+  version_output?: string | null
+  diagnostic?: string | null
+}
+
+export type ElementPropertyMetadata = {
+  name: string
+  description?: string | null
+}
+
+export type ElementPadTemplateMetadata = {
+  name: string
+  direction: string
+  presence?: string | null
+}
+
+export type ElementMetadataResponse = {
+  available: boolean
+  authority: MetadataAuthority
+  factory_name: string
+  long_name?: string | null
+  klass?: string | null
+  description?: string | null
+  plugin_name?: string | null
+  properties: ElementPropertyMetadata[]
+  pad_templates: ElementPadTemplateMetadata[]
+  raw_output?: string | null
+  diagnostic?: string | null
+}
+
 export function isTauriRuntime() {
   return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in (window as TauriWindow)
 }
@@ -90,6 +124,16 @@ export async function parsePipelineText(rawText: string, sourceName?: string) {
 
 export async function loadLocalPipelineFile(path: string) {
   return invoke<BackendPipelineDocument>('load_local_pipeline_file', { path })
+}
+
+export async function probeLocalGStreamer() {
+  return invoke<GStreamerProbeResponse>('probe_local_gstreamer')
+}
+
+export async function inspectLocalElement(factoryName: string) {
+  return invoke<ElementMetadataResponse>('inspect_local_element', {
+    factoryName,
+  })
 }
 
 export async function probeRemoteTarget(
@@ -115,5 +159,18 @@ export async function loadRemotePipeline(
       port: Number(request.port || 22),
     },
     path,
+  })
+}
+
+export async function inspectRemoteElement(
+  request: RemoteTargetInput,
+  factoryName: string,
+) {
+  return invoke<ElementMetadataResponse>('inspect_remote_element', {
+    request: {
+      ...request,
+      port: Number(request.port || 22),
+    },
+    factoryName,
   })
 }

--- a/src/features/home/HomeScreen.tsx
+++ b/src/features/home/HomeScreen.tsx
@@ -1,24 +1,44 @@
 import type { ChangeEvent } from 'react'
+import type { RemoteTargetInput } from '../../app/backend.ts'
 
 type HomeScreenProps = {
   isTauri: boolean
   pipelineText: string
+  remotePath: string
+  remoteStatusMessage: string
+  remoteTarget: RemoteTargetInput
   statusMessage: string
   onFileSelected: (event: ChangeEvent<HTMLInputElement>) => void
+  onLoadRemotePipeline: () => void
   onParseText: () => void
   onPipelineTextChange: (value: string) => void
+  onProbeRemote: () => void
+  onRemotePathChange: (value: string) => void
+  onRemoteTargetChange: (value: RemoteTargetInput) => void
 }
 
 function HomeScreen({
   isTauri,
   onFileSelected,
+  onLoadRemotePipeline,
   pipelineText,
+  remotePath,
+  remoteStatusMessage,
+  remoteTarget,
   statusMessage,
   onParseText,
   onPipelineTextChange,
+  onProbeRemote,
+  onRemotePathChange,
+  onRemoteTargetChange,
 }: HomeScreenProps) {
+  const canUseRemote =
+    remoteTarget.host.trim() &&
+    remoteTarget.username.trim() &&
+    remoteTarget.password.trim()
+
   return (
-    <main className="app-shell">
+    <main className="app-shell app-shell--home">
       <section className="home-screen home-screen--focused">
         <section className="launcher-card panel">
           <div className="launcher-card__header">
@@ -29,12 +49,12 @@ function HomeScreen({
             </div>
 
             <div className="launcher-card__copy">
-              <div className="eyebrow">로컬 파이프라인</div>
+              <div className="eyebrow">로컬 파일 / Remote Server</div>
               <h1>GStreamer Topology</h1>
               <p className="hero-body">
                 로컬 `.pld`, `.txt`, `.rtf` 파일을 가져오거나 파이프라인 텍스트를
-                붙여넣어 캔버스 중심 토폴로지 보기로 변환하세요. 예제 파일은 저장소의{' '}
-                <code>fixtures/pipelines/</code> 폴더에 있습니다.
+                붙여넣고, Remote Server의 OE-Linux 파이프라인도 같은 캔버스에서
+                확인하세요. 예제 파일은 <code>fixtures/pipelines/</code> 폴더에 있습니다.
               </p>
             </div>
           </div>
@@ -88,6 +108,108 @@ function HomeScreen({
                 </div>
               </div>
             </div>
+
+            <div className="launcher-divider" role="presentation">
+              <span>또는 Remote Server에서 불러오기</span>
+            </div>
+
+            <section className="remote-card">
+              <div className="remote-card__grid">
+                <label>
+                  <span className="field-label">IP</span>
+                  <input
+                    className="text-field"
+                    onChange={(event) =>
+                      onRemoteTargetChange({
+                        ...remoteTarget,
+                        host: event.target.value,
+                      })
+                    }
+                    placeholder="192.168.0.10"
+                    value={remoteTarget.host}
+                  />
+                </label>
+                <label>
+                  <span className="field-label">Port</span>
+                  <input
+                    className="text-field"
+                    min={1}
+                    onChange={(event) =>
+                      onRemoteTargetChange({
+                        ...remoteTarget,
+                        port: Number(event.target.value || 22),
+                      })
+                    }
+                    type="number"
+                    value={remoteTarget.port}
+                  />
+                </label>
+                <label>
+                  <span className="field-label">ID</span>
+                  <input
+                    className="text-field"
+                    onChange={(event) =>
+                      onRemoteTargetChange({
+                        ...remoteTarget,
+                        username: event.target.value,
+                      })
+                    }
+                    placeholder="root"
+                    value={remoteTarget.username}
+                  />
+                </label>
+                <label>
+                  <span className="field-label">PW</span>
+                  <input
+                    className="text-field"
+                    onChange={(event) =>
+                      onRemoteTargetChange({
+                        ...remoteTarget,
+                        password: event.target.value,
+                      })
+                    }
+                    type="password"
+                    value={remoteTarget.password}
+                  />
+                </label>
+              </div>
+
+              <label className="remote-card__path">
+                <span className="field-label">Remote Server Pipeline 파일 경로</span>
+                <input
+                  className="text-field"
+                  onChange={(event) => onRemotePathChange(event.target.value)}
+                  placeholder="/home/root/pipeline.pld"
+                  value={remotePath}
+                />
+              </label>
+
+              <div className="launcher-card__footer">
+                <div className="remote-card__actions">
+                  <button
+                    className="secondary-button"
+                    disabled={!canUseRemote}
+                    onClick={onProbeRemote}
+                    type="button"
+                  >
+                    원격 접속 확인
+                  </button>
+                  <button
+                    className="secondary-button"
+                    disabled={!canUseRemote || !remotePath.trim()}
+                    onClick={onLoadRemotePipeline}
+                    type="button"
+                  >
+                    원격 토폴로지 생성
+                  </button>
+                </div>
+
+                <div className="status-strip">
+                  <span className="card-chip muted-chip">읽기 전용 SSH/SFTP</span>
+                  <span className="status-message">{remoteStatusMessage}</span>
+                </div>
+              </div>
+            </section>
           </div>
         </section>
       </section>

--- a/src/features/inspector/InspectorPanel.tsx
+++ b/src/features/inspector/InspectorPanel.tsx
@@ -1,3 +1,4 @@
+import type { ElementMetadataResponse } from '../../app/backend.ts'
 import type {
   PipelineDiagnostic,
   PipelineDocumentViewModel,
@@ -7,6 +8,11 @@ import type {
 
 type InspectorPanelProps = {
   document: PipelineDocumentViewModel
+  metadata?: {
+    data?: ElementMetadataResponse
+    message?: string
+    status: 'loading' | 'ready' | 'unavailable'
+  }
   selectedNode: PipelineNodeViewModel | null
 }
 
@@ -78,7 +84,11 @@ function renderDiagnostic(diagnostic: PipelineDiagnostic) {
   )
 }
 
-function InspectorPanel({ document, selectedNode }: InspectorPanelProps) {
+function metadataAuthorityLabel(metadata: ElementMetadataResponse) {
+  return metadata.authority === 'remote' ? '원격 GStreamer' : '로컬 GStreamer'
+}
+
+function InspectorPanel({ document, metadata, selectedNode }: InspectorPanelProps) {
   if (!selectedNode) {
     return (
       <aside className="workspace-panel inspector-panel">
@@ -136,6 +146,81 @@ function InspectorPanel({ document, selectedNode }: InspectorPanelProps) {
           </ul>
         ) : (
           <p className="muted-copy">아직 캡처된 명시적 속성이 없습니다.</p>
+        )}
+      </section>
+
+      <section className="inspector-section">
+        <h3>Element 내부 정보</h3>
+        {!metadata || metadata.status === 'loading' ? (
+          <div className="metadata-card">
+            <span className="card-chip muted-chip">조회 중</span>
+            <p>선택한 Element의 GStreamer 메타데이터를 확인하고 있습니다.</p>
+          </div>
+        ) : metadata.status === 'unavailable' || !metadata.data?.available ? (
+          <div className="metadata-card">
+            <span className="card-chip muted-chip">텍스트 파서 기준</span>
+            <p>
+              {metadata.message ??
+                '이 환경에서 해당 Element의 GStreamer 내부 정보를 가져오지 못했습니다.'}
+            </p>
+          </div>
+        ) : (
+          <div className="metadata-card">
+            <div className="inspector-card__header">
+              <span className="card-chip">{metadataAuthorityLabel(metadata.data)}</span>
+              {metadata.data.plugin_name ? (
+                <span className="card-chip muted-chip">{metadata.data.plugin_name}</span>
+              ) : null}
+            </div>
+            <dl className="metadata-list">
+              {metadata.data.long_name ? (
+                <>
+                  <dt>Long name</dt>
+                  <dd>{metadata.data.long_name}</dd>
+                </>
+              ) : null}
+              {metadata.data.klass ? (
+                <>
+                  <dt>Klass</dt>
+                  <dd>{metadata.data.klass}</dd>
+                </>
+              ) : null}
+              {metadata.data.description ? (
+                <>
+                  <dt>Description</dt>
+                  <dd>{metadata.data.description}</dd>
+                </>
+              ) : null}
+            </dl>
+
+            {metadata.data.pad_templates.length ? (
+              <div className="metadata-subsection">
+                <span className="field-label">Pad templates</span>
+                <ul className="metadata-pill-list">
+                  {metadata.data.pad_templates.slice(0, 6).map((pad) => (
+                    <li key={`${pad.direction}-${pad.name}`}>
+                      {pad.direction} · {pad.name}
+                      {pad.presence ? ` · ${pad.presence}` : ''}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+
+            {metadata.data.properties.length ? (
+              <div className="metadata-subsection">
+                <span className="field-label">GStreamer properties</span>
+                <ul className="metadata-property-list">
+                  {metadata.data.properties.slice(0, 8).map((property) => (
+                    <li key={property.name}>
+                      <span>{property.name}</span>
+                      {property.description ? <small>{property.description}</small> : null}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+          </div>
         )}
       </section>
 

--- a/src/features/workspace/SourceTextPanel.tsx
+++ b/src/features/workspace/SourceTextPanel.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef } from 'react'
+import type {
+  PipelineDiagnostic,
+  PipelineDocumentViewModel,
+  PipelineNodeViewModel,
+  SourceSpan,
+} from '../../graph/types.ts'
+
+type SourceTextPanelProps = {
+  document: PipelineDocumentViewModel
+  isOpen: boolean
+  selectedNode: PipelineNodeViewModel | null
+  onToggle: () => void
+}
+
+const encoder = new TextEncoder()
+
+function byteOffsetToStringIndex(text: string, byteOffset: number) {
+  let bytes = 0
+  let index = 0
+
+  for (const char of text) {
+    const nextBytes = bytes + encoder.encode(char).length
+    if (nextBytes > byteOffset) {
+      return index
+    }
+
+    bytes = nextBytes
+    index += char.length
+  }
+
+  return text.length
+}
+
+function clampSpan(text: string, span?: SourceSpan) {
+  if (!span || typeof span.start !== 'number' || typeof span.end !== 'number') {
+    return null
+  }
+
+  const start = byteOffsetToStringIndex(text, Math.max(0, span.start))
+  const end = byteOffsetToStringIndex(text, Math.max(span.start, span.end))
+
+  return {
+    start: Math.min(start, text.length),
+    end: Math.min(Math.max(end, start), text.length),
+  }
+}
+
+function syntaxDiagnostics(diagnostics: PipelineDiagnostic[]) {
+  return diagnostics.filter((diagnostic) => diagnostic.severity !== 'info')
+}
+
+function SourceTextPanel({
+  document,
+  isOpen,
+  selectedNode,
+  onToggle,
+}: SourceTextPanelProps) {
+  const highlightRef = useRef<HTMLElement | null>(null)
+  const text = document.normalizedText
+  const selectedSpan = clampSpan(text, selectedNode?.sourceSpan)
+  const diagnostics = syntaxDiagnostics(document.diagnostics)
+
+  const highlightedText = selectedSpan
+    ? {
+        before: text.slice(0, selectedSpan.start),
+        selected: text.slice(selectedSpan.start, selectedSpan.end),
+        after: text.slice(selectedSpan.end),
+      }
+    : { before: text, selected: '', after: '' }
+
+  useEffect(() => {
+    if (!isOpen || !highlightRef.current) {
+      return
+    }
+
+    highlightRef.current.scrollIntoView({
+      block: 'center',
+      behavior: 'smooth',
+    })
+  }, [isOpen, selectedNode?.id])
+
+  return (
+    <section className={isOpen ? 'source-panel is-open' : 'source-panel'}>
+      <button className="source-panel__toggle" onClick={onToggle} type="button">
+        <span>
+          <strong>Pipeline 원문</strong>
+          {selectedNode?.sourceSpan ? (
+            <em>
+              선택 위치: {selectedNode.sourceSpan.lineStart}-{selectedNode.sourceSpan.lineEnd}행
+            </em>
+          ) : (
+            <em>선택한 Element의 원문 위치를 함께 확인합니다.</em>
+          )}
+        </span>
+        <span className="card-chip">{isOpen ? '접기' : '보기'}</span>
+      </button>
+
+      {isOpen ? (
+        <div className="source-panel__body">
+          {diagnostics.length ? (
+            <div className="source-panel__alert">
+              파서 진단 {diagnostics.length}건이 있습니다. 원문과 캔버스를 함께 보며
+              연결 상태를 확인하세요.
+            </div>
+          ) : null}
+
+          <pre className="source-panel__code">
+            <code>
+              <span>{highlightedText.before}</span>
+              {highlightedText.selected ? (
+                <mark ref={highlightRef}>{highlightedText.selected}</mark>
+              ) : null}
+              <span>{highlightedText.after}</span>
+            </code>
+          </pre>
+        </div>
+      ) : null}
+    </section>
+  )
+}
+
+export { SourceTextPanel }

--- a/src/features/workspace/WorkspaceShell.tsx
+++ b/src/features/workspace/WorkspaceShell.tsx
@@ -1,7 +1,17 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import {
+  inspectLocalElement,
+  inspectRemoteElement,
+  isTauriRuntime,
+  probeLocalGStreamer,
+  type ElementMetadataResponse,
+  type GStreamerProbeResponse,
+  type RemoteTargetInput,
+} from '../../app/backend.ts'
 import { InspectorPanel } from '../inspector/InspectorPanel.tsx'
 import { GraphCanvas } from '../../graph/GraphCanvas.tsx'
 import { DiagnosticsPanel } from './DiagnosticsPanel.tsx'
+import { SourceTextPanel } from './SourceTextPanel.tsx'
 import type {
   PipelineDocumentViewModel,
   PipelineNodeViewModel,
@@ -9,7 +19,14 @@ import type {
 
 type WorkspaceShellProps = {
   document: PipelineDocumentViewModel
+  remoteTarget: RemoteTargetInput | null
   onBackHome: () => void
+}
+
+type MetadataEntry = {
+  data?: ElementMetadataResponse
+  message?: string
+  status: 'loading' | 'ready' | 'unavailable'
 }
 
 function findNode(
@@ -36,6 +53,7 @@ function getParserStatusLabel(status: PipelineDocumentViewModel['parserStatus'])
 
 function WorkspaceShell({
   document,
+  remoteTarget,
   onBackHome,
 }: WorkspaceShellProps) {
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(
@@ -44,11 +62,101 @@ function WorkspaceShell({
   const [isDiagnosticsOpen, setIsDiagnosticsOpen] = useState(
     document.diagnostics.some((diagnostic) => diagnostic.severity !== 'info'),
   )
+  const [isSourceOpen, setIsSourceOpen] = useState(false)
+  const [localProbe, setLocalProbe] = useState<GStreamerProbeResponse | null>(null)
+  const [metadataByFactory, setMetadataByFactory] = useState<Record<string, MetadataEntry>>({})
 
   const selectedNode = findNode(document, selectedNodeId)
+  const syntaxDiagnostics = document.diagnostics.filter(
+    (diagnostic) => diagnostic.severity !== 'info',
+  )
+  const selectedMetadata = selectedNode
+    ? metadataByFactory[selectedNode.factoryName]
+    : undefined
+  const metadataAuthority =
+    document.sourceKind === 'remote_file' ? '원격 GStreamer' : '로컬 GStreamer'
+
+  useEffect(() => {
+    if (!isTauriRuntime() || document.sourceKind === 'remote_file') {
+      return
+    }
+
+    let isCancelled = false
+    probeLocalGStreamer()
+      .then((response) => {
+        if (!isCancelled) {
+          setLocalProbe(response)
+        }
+      })
+      .catch(() => {
+        if (!isCancelled) {
+          setLocalProbe({
+            available: false,
+            authority: 'local',
+            diagnostic: '로컬 GStreamer 확인에 실패했습니다.',
+            version_output: null,
+          })
+        }
+      })
+
+    return () => {
+      isCancelled = true
+    }
+  }, [document.id, document.sourceKind])
+
+  useEffect(() => {
+    if (!selectedNode || !isTauriRuntime()) {
+      return
+    }
+
+    const key = selectedNode.factoryName
+    if (metadataByFactory[key]) {
+      return
+    }
+
+    let isCancelled = false
+    const loader =
+      document.sourceKind === 'remote_file' && remoteTarget
+        ? inspectRemoteElement(remoteTarget, selectedNode.factoryName)
+        : inspectLocalElement(selectedNode.factoryName)
+
+    loader
+      .then((metadata) => {
+        if (isCancelled) {
+          return
+        }
+
+        setMetadataByFactory((current) => ({
+          ...current,
+          [key]: {
+            data: metadata,
+            message: metadata.diagnostic ?? undefined,
+            status: metadata.available ? 'ready' : 'unavailable',
+          },
+        }))
+      })
+      .catch((error) => {
+        if (isCancelled) {
+          return
+        }
+
+        console.error(error)
+        setMetadataByFactory((current) => ({
+          ...current,
+          [key]: {
+            message: 'Element 메타데이터를 가져오지 못했습니다.',
+            status: 'unavailable',
+          },
+        }))
+      })
+
+    return () => {
+      isCancelled = true
+    }
+  }, [document.sourceKind, metadataByFactory, remoteTarget, selectedNode])
 
   return (
-    <main className="app-shell">
+    <main className="app-shell app-shell--workspace">
       <section className="workspace-shell">
         <header className="workspace-topbar panel">
           <div className="workspace-topbar__meta">
@@ -68,6 +176,18 @@ function WorkspaceShell({
               노드 {document.graph.nodes.length}개 / 엣지 {document.graph.edges.length}개
             </span>
             <span className="card-chip">{getParserStatusLabel(document.parserStatus)}</span>
+            <span className="card-chip">{metadataAuthority}</span>
+            <button
+              className={
+                isSourceOpen
+                  ? 'secondary-button diagnostics-toggle is-active'
+                  : 'secondary-button diagnostics-toggle'
+              }
+              onClick={() => setIsSourceOpen((current) => !current)}
+              type="button"
+            >
+              Pipeline 원문
+            </button>
             <button
               className={
                 isDiagnosticsOpen
@@ -82,12 +202,39 @@ function WorkspaceShell({
           </div>
         </header>
 
+        {syntaxDiagnostics.length ? (
+          <aside className="workspace-alert severity-warning">
+            <strong>파이프라인 구문 확인 필요</strong>
+            <span>
+              토폴로지는 생성됐지만 파서 진단 {syntaxDiagnostics.length}건이 있습니다.
+              Element 연결의 의미 검증은 이후 단계에서 보강하고, 현재는 원문과 진단을
+              함께 확인해 주세요.
+            </span>
+          </aside>
+        ) : null}
+
+        {localProbe && !localProbe.available ? (
+          <aside className="workspace-alert severity-info">
+            <strong>로컬 GStreamer 정보 없음</strong>
+            <span>
+              이 장비에서 `gst-inspect-1.0`을 찾지 못했습니다. 토폴로지는 텍스트 파서
+              기준으로 계속 표시하고, Element 내부 정보는 설치 후 확인할 수 있습니다.
+            </span>
+          </aside>
+        ) : null}
+
         <div className="workspace-grid">
           <section className="workspace-main">
             <GraphCanvas
               document={document}
               selectedNodeId={selectedNodeId}
               onSelectNode={setSelectedNodeId}
+            />
+            <SourceTextPanel
+              document={document}
+              isOpen={isSourceOpen}
+              selectedNode={selectedNode}
+              onToggle={() => setIsSourceOpen((current) => !current)}
             />
             <DiagnosticsPanel
               diagnostics={document.diagnostics}
@@ -96,7 +243,11 @@ function WorkspaceShell({
             />
           </section>
 
-          <InspectorPanel document={document} selectedNode={selectedNode} />
+          <InspectorPanel
+            document={document}
+            metadata={selectedMetadata}
+            selectedNode={selectedNode}
+          />
         </div>
       </section>
     </main>

--- a/src/graph/GraphCanvas.tsx
+++ b/src/graph/GraphCanvas.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
+  applyNodeChanges,
   Background,
   BackgroundVariant,
   Controls,
@@ -7,12 +8,12 @@ import {
   Panel,
   ReactFlow,
   type Edge,
-  type Node,
+  type NodeChange,
   type NodeMouseHandler,
   type ReactFlowInstance,
 } from '@xyflow/react'
 import { TechnicalNode } from './nodes/TechnicalNode.tsx'
-import { toReactFlowEdges, toReactFlowNodes } from './toReactFlow.ts'
+import { toReactFlowEdges, toReactFlowNodes, type TechnicalFlowNode } from './toReactFlow.ts'
 import type { PipelineDocumentViewModel } from './types.ts'
 
 type GraphCanvasProps = {
@@ -25,23 +26,93 @@ const nodeTypes = {
   technical: TechnicalNode,
 }
 
+const minimapToneColors: Record<TechnicalFlowNode['data']['tone'], string> = {
+  ai: '#2ec9d1',
+  branch: '#7c8dff',
+  merge: '#35b99f',
+  output: '#64748b',
+  source: '#158dff',
+  unknown: '#94a3b8',
+  utility: '#8b9cff',
+}
+
+function getMinimapNodeColor(node: TechnicalFlowNode) {
+  return minimapToneColors[node.data.tone] ?? minimapToneColors.unknown
+}
+
+function getMinimapNodeStrokeColor(node: TechnicalFlowNode) {
+  return node.data.isSelected ? '#ffffff' : 'rgba(2, 18, 36, 0.72)'
+}
+
+function graphSignature(document: PipelineDocumentViewModel) {
+  return [
+    document.graph.nodes.map((node) => node.id).join(','),
+    document.graph.edges
+      .map((edge) => (
+        `${edge.sourceNodeId}:${edge.sourcePort?.name ?? 'src'}->${edge.targetNodeId}:${edge.targetPort?.name ?? 'sink'}`
+      ))
+      .join(','),
+  ].join('|')
+}
+
+function storageKey(document: PipelineDocumentViewModel) {
+  return `gst-topology-layout:${document.id}:${graphSignature(document)}`
+}
+
+type StoredPositions = Record<string, { x: number; y: number }>
+
+function readStoredPositions(key: string): StoredPositions {
+  const stored = localStorage.getItem(key)
+  if (!stored) {
+    return {}
+  }
+
+  try {
+    return JSON.parse(stored) as StoredPositions
+  } catch {
+    return {}
+  }
+}
+
+function extractPositions(nodes: TechnicalFlowNode[]) {
+  return Object.fromEntries(
+    nodes.map((node) => [node.id, node.position]),
+  )
+}
+
+function savePositions(positions: StoredPositions, key: string) {
+  localStorage.setItem(key, JSON.stringify(positions))
+}
+
 function GraphCanvas({
   document,
   selectedNodeId,
   onSelectNode,
 }: GraphCanvasProps) {
-  const [flow, setFlow] = useState<ReactFlowInstance<Node, Edge> | null>(null)
+  const [flow, setFlow] = useState<ReactFlowInstance<TechnicalFlowNode, Edge> | null>(null)
+  const key = storageKey(document)
   const selectedNode = document.graph.nodes.find((node) => node.id === selectedNodeId) ?? null
-
-  const nodes = toReactFlowNodes({
+  const renderedNodes = useMemo(() => toReactFlowNodes({
     graph: document.graph,
     searchValue: '',
     selectedNodeId,
-  })
-  const edges = toReactFlowEdges({
+  }), [document.graph, selectedNodeId])
+  const [manualPositions, setManualPositions] = useState<StoredPositions>(() =>
+    readStoredPositions(key),
+  )
+  const nodes = useMemo(
+    () =>
+      renderedNodes.map((node) => ({
+        ...node,
+        position: manualPositions[node.id] ?? node.position,
+      })),
+    [manualPositions, renderedNodes],
+  )
+  const hasManualLayout = Object.keys(manualPositions).length > 0
+  const edges = useMemo(() => toReactFlowEdges({
     graph: document.graph,
     selectedNodeId,
-  })
+  }), [document.graph, selectedNodeId])
 
   useEffect(() => {
     if (!flow || !nodes.length) {
@@ -59,7 +130,7 @@ function GraphCanvas({
       return
     }
 
-    const selectedNode = nodes.find((node) => node.id === selectedNodeId)
+    const selectedNode = flow.getNode(selectedNodeId)
 
     if (!selectedNode) {
       return
@@ -69,16 +140,42 @@ function GraphCanvas({
       duration: 280,
       zoom: 0.92,
     })
-  }, [flow, nodes, selectedNodeId])
+  }, [flow, selectedNodeId])
 
-  const handleNodeClick: NodeMouseHandler<Node> = (_, node) => {
+  const handleNodeClick: NodeMouseHandler<TechnicalFlowNode> = (_, node) => {
     onSelectNode(node.id)
+  }
+  const handleNodesChange = (changes: NodeChange<TechnicalFlowNode>[]) => {
+    const positionChanges = changes.filter(
+      (change) => change.type === 'position' && change.position,
+    )
+
+    if (!positionChanges.length) {
+      return
+    }
+
+    const nextNodes = applyNodeChanges(positionChanges, nodes)
+    setManualPositions(extractPositions(nextNodes))
+  }
+  const handleNodeDragStop: NodeMouseHandler<TechnicalFlowNode> = () => {
+    const currentNodes = (flow?.getNodes() as TechnicalFlowNode[] | undefined) ?? nodes
+    const positions = extractPositions(currentNodes)
+    setManualPositions(positions)
+    savePositions(positions, key)
+  }
+  const handleResetLayout = () => {
+    localStorage.removeItem(key)
+    setManualPositions({})
+    flow?.fitView({
+      duration: 320,
+      padding: 0.18,
+    })
   }
 
   return (
     <section className="workspace-panel canvas-panel">
       <div className="graph-stage">
-        <ReactFlow
+        <ReactFlow<TechnicalFlowNode, Edge>
           defaultEdgeOptions={{ type: 'smoothstep' }}
           edges={edges}
           fitView
@@ -88,6 +185,8 @@ function GraphCanvas({
           nodes={nodes}
           onInit={setFlow}
           onNodeClick={handleNodeClick}
+          onNodeDragStop={handleNodeDragStop}
+          onNodesChange={handleNodesChange}
           onPaneClick={() => onSelectNode(null)}
           proOptions={{ hideAttribution: true }}
         >
@@ -98,10 +197,17 @@ function GraphCanvas({
             variant={BackgroundVariant.Dots}
           />
           <MiniMap
+            bgColor="rgba(229, 238, 248, 0.96)"
             className="graph-minimap"
-            maskColor="rgba(9, 18, 30, 0.12)"
-            nodeBorderRadius={18}
-            nodeColor="var(--minimap-node)"
+            maskColor="rgba(9, 23, 42, 0.24)"
+            maskStrokeColor="rgba(21, 88, 155, 0.72)"
+            maskStrokeWidth={2}
+            nodeBorderRadius={8}
+            nodeColor={getMinimapNodeColor}
+            nodeStrokeColor={getMinimapNodeStrokeColor}
+            nodeStrokeWidth={2.4}
+            pannable
+            zoomable
           />
           <Controls position="bottom-left" showInteractive={false} />
           <Panel className="graph-badge" position="top-left">
@@ -115,6 +221,9 @@ function GraphCanvas({
           <Panel className="graph-badge graph-badge--stats" position="top-right">
             <span>노드 {document.graph.nodes.length}개</span>
             <span>엣지 {document.graph.edges.length}개</span>
+            <button className="graph-inline-action" onClick={handleResetLayout} type="button">
+              {hasManualLayout ? '레이아웃 초기화' : '자동 배치'}
+            </button>
           </Panel>
         </ReactFlow>
 

--- a/src/graph/fromBackend.ts
+++ b/src/graph/fromBackend.ts
@@ -3,17 +3,21 @@ import type {
   BackendParseDiagnostic,
   BackendPipelineDocument,
   BackendPipelineNode,
+  BackendPipelinePort,
   BackendSourceSpan,
 } from '../app/backend.ts'
 import type {
   PipelineDiagnostic,
   PipelineDocumentViewModel,
   PipelineGraphViewModel,
+  PipelinePortViewModel,
   PipelineNodeTone,
   PipelineNodeViewModel,
 } from './types.ts'
 
 const elk = new ELK()
+const DEFAULT_NODE_HEIGHT = 118
+const DEFAULT_NODE_WIDTH = 220
 
 function sourceKindLabel(sourceKind: BackendPipelineDocument['source_kind']) {
   switch (sourceKind) {
@@ -100,6 +104,8 @@ function toLineSpan(text: string, span: BackendSourceSpan | undefined | null) {
   }
 
   return {
+    start: span.start,
+    end: span.end,
     lineStart: countLineBreaks(text, span.start),
     lineEnd: countLineBreaks(text, span.end),
   }
@@ -142,7 +148,8 @@ function classifyTone(node: BackendPipelineNode): PipelineNodeTone {
   if (
     factory === 'funnel' ||
     factory.includes('mux') ||
-    factory.includes('composer')
+    factory.includes('composer') ||
+    factory.includes('compositor')
   ) {
     return 'merge'
   }
@@ -200,6 +207,59 @@ function nodeTags(node: BackendPipelineNode) {
   return Array.from(tags).slice(0, 4)
 }
 
+function nodeDimensions(node: BackendPipelineNode) {
+  return {
+    width: Math.max(DEFAULT_NODE_WIDTH, (node.instance_name || node.factory_name).length * 8 + 120),
+    height: DEFAULT_NODE_HEIGHT,
+  }
+}
+
+function portViewModel(
+  port: BackendPipelinePort | null | undefined,
+): PipelinePortViewModel | undefined {
+  if (!port) {
+    return undefined
+  }
+
+  return {
+    id: port.id,
+    kind: port.port_kind,
+    name: port.port_name,
+    nodeId: port.node_id,
+  }
+}
+
+function portDirectionLabel(port: PipelinePortViewModel | undefined, fallback: 'SRC' | 'SINK') {
+  if (!port) {
+    return fallback
+  }
+
+  const direction =
+    port.kind === 'src'
+      ? 'SRC'
+      : port.kind === 'sink' || port.kind === 'request'
+        ? 'SINK'
+        : fallback
+  const shouldShowName =
+    port.kind === 'request' ||
+    port.kind === 'named' ||
+    (direction === 'SINK' && port.name !== 'sink') ||
+    (direction === 'SRC' && port.name !== 'src')
+
+  return shouldShowName ? `${direction} ${port.name}` : direction
+}
+
+function edgeLabel(edge: BackendPipelineDocument['graph']['edges'][number]) {
+  const sourcePort = portViewModel(edge.source_port)
+  const targetPort = portViewModel(edge.target_port)
+  const flowLabel = `${portDirectionLabel(sourcePort, 'SRC')} -> ${portDirectionLabel(
+    targetPort,
+    'SINK',
+  )}`
+
+  return edge.caps_label ? `${flowLabel} · ${edge.caps_label}` : flowLabel
+}
+
 function buildWarnings(
   node: BackendPipelineNode,
   diagnostics: BackendParseDiagnostic[],
@@ -211,9 +271,7 @@ function buildWarnings(
         return false
       }
 
-        return (
-          span.start <= node.source_span.end && span.end >= node.source_span.start
-      )
+      return span.start <= node.source_span.end && span.end >= node.source_span.start
     })
     .map(localizeDiagnosticMessage)
 }
@@ -234,8 +292,7 @@ async function layoutNodes(
     },
     children: nodes.map((node) => ({
       id: node.id,
-      width: Math.max(220, (node.instance_name || node.factory_name).length * 8 + 120),
-      height: 118,
+      ...nodeDimensions(node),
     })),
     edges: edges.map((edge) => ({
       id: edge.id,
@@ -255,6 +312,7 @@ async function layoutNodes(
   const viewNodes: PipelineNodeViewModel[] = nodes.map((node) => ({
     id: node.id,
     description: summarizeNode(node),
+    dimensions: nodeDimensions(node),
     factoryName: node.factory_name,
     instanceName: node.instance_name ?? undefined,
     kind: node.kind,
@@ -278,6 +336,7 @@ export async function toViewModel(
       severity: severityLabel(diagnostic.severity),
       message: localizeDiagnosticMessage(diagnostic),
       nodeId: undefined,
+      sourceSpan: toLineSpan(document.normalized_text, diagnostic.span),
     }),
   )
 
@@ -297,13 +356,11 @@ export async function toViewModel(
     })),
     edges: document.graph.edges.map((edge) => ({
       id: edge.id,
+      label: edgeLabel(edge),
+      sourcePort: portViewModel(edge.source_port),
       sourceNodeId: edge.source_node_id,
+      targetPort: portViewModel(edge.target_port),
       targetNodeId: edge.target_node_id,
-      label:
-        edge.caps_label ??
-        edge.target_port?.port_name ??
-        edge.source_port?.port_name ??
-        undefined,
     })),
   }
 
@@ -314,6 +371,7 @@ export async function toViewModel(
     sourceKind: document.source_kind,
     sourceLabel: document.path ?? document.source_name ?? defaultSourceLabel(document.source_kind),
     parserStatus: graph.nodes.length ? 'parsed' : 'placeholder',
+    normalizedText: document.normalized_text,
     normalizedTextPreview: document.normalized_text.slice(0, 340),
     diagnostics,
     graph,

--- a/src/graph/mockDocuments.ts
+++ b/src/graph/mockDocuments.ts
@@ -7,6 +7,7 @@ const blankDocument: PipelineDocumentViewModel = {
   sourceKind: 'sample',
   sourceLabel: 'Canvas shell only',
   parserStatus: 'empty',
+  normalizedText: 'Paste or open a pipeline to populate the graph.',
   normalizedTextPreview: 'Paste or open a pipeline to populate the graph.',
   diagnostics: [
     {
@@ -28,6 +29,8 @@ const pipmuxDocument: PipelineDocumentViewModel = {
   sourceKind: 'sample',
   sourceLabel: '27_pipmux.pld.rtf',
   parserStatus: 'parsed',
+  normalizedText:
+    'qtiqmmfsrc name=eocam0 ! tee name=eoraw ! ... output-selector name=eo_sr_in ... qtivcomposer name=mixer',
   normalizedTextPreview:
     'qtiqmmfsrc name=eocam0 ! tee name=eoraw ! ... output-selector name=eo_sr_in ... qtivcomposer name=mixer',
   diagnostics: [
@@ -289,6 +292,8 @@ const smoothingDocument: PipelineDocumentViewModel = {
   sourceKind: 'sample',
   sourceLabel: '26_release_record_smoothing.pld.rtf',
   parserStatus: 'parsed',
+  normalizedText:
+    'qtiqmmfsrc camera=0 name=eocam0 ! tee name=eoraw ! ... qtivcomposer name=mixer',
   normalizedTextPreview:
     'qtiqmmfsrc name=eocam0 ! tee name=eoraw ! ... splitmuxsink name=tsrec_eo ... tee name=eoenc',
   diagnostics: [

--- a/src/graph/nodes/TechnicalNode.tsx
+++ b/src/graph/nodes/TechnicalNode.tsx
@@ -29,8 +29,12 @@ function TechnicalNode({ data }: NodeProps<TechnicalFlowNode>) {
         .join(' ')}
     >
       <Handle className="technical-node__handle" position={Position.Left} type="target" />
+      <span className="technical-node__port-label technical-node__port-label--sink">SINK</span>
       <div className="technical-node__eyebrow">
         <span>{nodeKindLabel(data.kind)}</span>
+        <span className="technical-node__drag-handle" title="위치 이동">
+          ::
+        </span>
         {data.warningCount ? <span>경고 {data.warningCount}개</span> : null}
       </div>
       <strong>{data.label}</strong>
@@ -40,6 +44,7 @@ function TechnicalNode({ data }: NodeProps<TechnicalFlowNode>) {
           <span key={tag}>{tag}</span>
         ))}
       </div>
+      <span className="technical-node__port-label technical-node__port-label--src">SRC</span>
       <Handle className="technical-node__handle" position={Position.Right} type="source" />
     </div>
   )

--- a/src/graph/toReactFlow.ts
+++ b/src/graph/toReactFlow.ts
@@ -1,4 +1,4 @@
-import type { Edge, Node } from '@xyflow/react'
+import { MarkerType, type Edge, type Node } from '@xyflow/react'
 import type {
   PipelineGraphViewModel,
   PipelineNodeTone,
@@ -28,6 +28,10 @@ type TechnicalNodeData = {
 }
 
 type TechnicalFlowNode = Node<TechnicalNodeData, 'technical'>
+const DEFAULT_NODE_DIMENSIONS = {
+  height: 118,
+  width: 220,
+}
 
 function matchesSearch(node: PipelineNodeViewModel, searchValue: string) {
   const normalizedQuery = searchValue.trim().toLowerCase()
@@ -48,22 +52,33 @@ function toReactFlowNodes({
   searchValue,
   selectedNodeId,
 }: ReactFlowNodeParams): TechnicalFlowNode[] {
-  return graph.nodes.map((node) => ({
-    id: node.id,
-    type: 'technical',
-    position: node.position,
-    draggable: false,
-    data: {
-      factoryName: node.factoryName,
-      kind: node.kind,
-      isSearchMatch: matchesSearch(node, searchValue),
-      isSelected: node.id === selectedNodeId,
-      label: node.instanceName || node.factoryName,
-      tags: node.tags,
-      tone: node.tone,
-      warningCount: node.warnings.length,
-    },
-  }))
+  return graph.nodes.map((node) => {
+    const dimensions = node.dimensions ?? DEFAULT_NODE_DIMENSIONS
+
+    return {
+      id: node.id,
+      type: 'technical',
+      position: node.position,
+      dragHandle: '.technical-node__drag-handle',
+      draggable: true,
+      height: dimensions.height,
+      width: dimensions.width,
+      style: {
+        height: dimensions.height,
+        width: dimensions.width,
+      },
+      data: {
+        factoryName: node.factoryName,
+        kind: node.kind,
+        isSearchMatch: matchesSearch(node, searchValue),
+        isSelected: node.id === selectedNodeId,
+        label: node.instanceName || node.factoryName,
+        tags: node.tags,
+        tone: node.tone,
+        warningCount: node.warnings.length,
+      },
+    }
+  })
 }
 
 function toReactFlowEdges({
@@ -80,19 +95,28 @@ function toReactFlowEdges({
       target: edge.targetNodeId,
       animated: isConnected,
       label: edge.label,
+      markerEnd: {
+        color: isConnected ? 'var(--edge-active)' : 'var(--edge-muted)',
+        height: 18,
+        type: MarkerType.ArrowClosed,
+        width: 18,
+      },
       style: {
         stroke: isConnected ? 'var(--edge-active)' : 'var(--edge-muted)',
-        strokeWidth: isConnected ? 2.4 : 1.4,
+        strokeLinecap: 'round',
+        strokeWidth: isConnected ? 2.6 : 1.6,
       },
       labelStyle: {
-        fill: 'var(--text-soft)',
-        fontSize: 12,
-        fontWeight: 600,
+        fill: isConnected ? 'var(--edge-active)' : 'var(--text-soft)',
+        fontSize: 11,
+        fontWeight: 800,
       },
       labelBgStyle: {
-        fill: 'rgba(245, 247, 251, 0.92)',
+        fill: 'rgba(247, 250, 253, 0.96)',
         fillOpacity: 1,
       },
+      labelBgBorderRadius: 8,
+      labelBgPadding: [6, 4] as [number, number],
     }
   })
 }

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -11,8 +11,10 @@ type PipelineNodeTone =
 type DiagnosticSeverity = 'info' | 'warning' | 'error'
 
 type SourceSpan = {
+  end?: number
   lineStart: number
   lineEnd: number
+  start?: number
 }
 
 type PipelineProperty = {
@@ -20,11 +22,21 @@ type PipelineProperty = {
   value: string
 }
 
+type PipelinePortKind = 'src' | 'sink' | 'named' | 'request'
+
+type PipelinePortViewModel = {
+  id: string
+  kind: PipelinePortKind
+  name: string
+  nodeId: string
+}
+
 type PipelineDiagnostic = {
   id: string
   message: string
   nodeId?: string
   severity: DiagnosticSeverity
+  sourceSpan?: SourceSpan
 }
 
 type PipelineNodeViewModel = {
@@ -33,6 +45,10 @@ type PipelineNodeViewModel = {
   factoryName: string
   instanceName?: string
   kind: PipelineNodeKind
+  dimensions?: {
+    width: number
+    height: number
+  }
   position: {
     x: number
     y: number
@@ -47,7 +63,9 @@ type PipelineNodeViewModel = {
 type PipelineEdgeViewModel = {
   id: string
   label?: string
+  sourcePort?: PipelinePortViewModel
   sourceNodeId: string
+  targetPort?: PipelinePortViewModel
   targetNodeId: string
 }
 
@@ -62,6 +80,7 @@ type PipelineDocumentViewModel = {
   id: string
   diagnostics: PipelineDiagnostic[]
   graph: PipelineGraphViewModel
+  normalizedText: string
   normalizedTextPreview: string
   parserStatus: PipelineParserStatus
   sourceKind: PipelineSourceKind
@@ -78,6 +97,8 @@ export type {
   PipelineNodeKind,
   PipelineNodeTone,
   PipelineNodeViewModel,
+  PipelinePortKind,
+  PipelinePortViewModel,
   PipelineProperty,
   PipelineSourceKind,
   SourceSpan,

--- a/src/styles/app-shell.css
+++ b/src/styles/app-shell.css
@@ -3,6 +3,16 @@
   padding: 20px;
 }
 
+.app-shell--workspace {
+  height: 100svh;
+  overflow: hidden;
+}
+
+.app-shell--home {
+  height: 100svh;
+  overflow: hidden;
+}
+
 .panel,
 .workspace-panel {
   background: var(--surface-base);
@@ -23,11 +33,12 @@
 }
 
 .launcher-card {
-  width: min(980px, 100%);
+  width: min(1180px, 100%);
+  max-height: calc(100svh - 40px);
   margin: 0 auto;
-  padding: 32px;
+  padding: clamp(18px, 2.4svh, 28px);
   display: grid;
-  gap: 28px;
+  gap: clamp(14px, 1.8svh, 22px);
   background:
     linear-gradient(180deg, rgba(246, 250, 255, 0.96), rgba(233, 241, 250, 0.84)),
     linear-gradient(135deg, rgba(21, 141, 255, 0.07), transparent 42%);
@@ -38,6 +49,8 @@
 .launcher-card__copy,
 .launcher-card__actions,
 .launcher-card__paste,
+.remote-card,
+.remote-card label,
 .section-heading,
 .workspace-shell,
 .workspace-main,
@@ -52,6 +65,7 @@
 
 .launcher-card__badges,
 .launcher-card__formats,
+.remote-card__actions,
 .status-strip,
 .workspace-topbar__actions,
 .inspector-card__header,
@@ -63,8 +77,8 @@
 }
 
 .launcher-card__copy {
-  gap: 14px;
-  max-width: 680px;
+  gap: 12px;
+  max-width: 860px;
 }
 
 .eyebrow {
@@ -80,10 +94,14 @@
 .workspace-topbar h1 {
   color: var(--ink-strong);
   font-family: var(--font-display);
-  font-size: clamp(2.2rem, 3.6vw, 4rem);
+  font-size: clamp(2.2rem, 3.4vw, 3.8rem);
   font-weight: 700;
   letter-spacing: -0.05em;
   line-height: 0.94;
+}
+
+.hero-body {
+  max-width: 860px;
 }
 
 .hero-body,
@@ -186,12 +204,35 @@
 }
 
 .launcher-card__paste {
-  gap: 14px;
+  gap: 12px;
+}
+
+.remote-card {
+  padding: 16px;
+  border: 1px solid rgba(23, 49, 82, 0.1);
+  border-radius: 22px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.76), rgba(235, 244, 252, 0.76)),
+    radial-gradient(circle at top right, rgba(21, 141, 255, 0.1), transparent 32%);
+}
+
+.remote-card__grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: minmax(160px, 1.3fr) minmax(90px, 0.6fr) minmax(140px, 1fr) minmax(140px, 1fr);
+}
+
+.remote-card__path {
+  display: grid;
+}
+
+.remote-card__actions {
+  align-items: center;
 }
 
 .launcher-card__footer {
   display: grid;
-  gap: 14px;
+  gap: 12px;
   align-items: start;
 }
 
@@ -217,7 +258,7 @@
 }
 
 .text-area {
-  min-height: 240px;
+  min-height: clamp(110px, 15svh, 170px);
   resize: vertical;
 }
 
@@ -285,7 +326,24 @@
   display: flex;
   justify-content: space-between;
   gap: 18px;
-  padding: 20px 22px;
+  padding: 16px 18px;
+}
+
+.workspace-alert {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 18px;
+  border: 1px solid var(--stroke-soft);
+  border-radius: 20px;
+  background: rgba(249, 252, 255, 0.78);
+  color: var(--text-soft);
+  box-shadow: var(--shadow-soft);
+}
+
+.workspace-alert strong {
+  flex: 0 0 auto;
+  color: var(--ink-strong);
 }
 
 .workspace-topbar__meta {
@@ -314,25 +372,38 @@
   color: var(--accent-primary);
 }
 
+.workspace-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .workspace-grid {
   display: grid;
+  flex: 1 1 auto;
   gap: 16px;
   grid-template-columns: minmax(0, 1fr) 340px;
-  min-height: calc(100svh - 150px);
+  min-height: 0;
+  overflow: hidden;
 }
 
 .workspace-main {
+  min-height: 0;
   min-width: 0;
-  grid-template-rows: minmax(560px, 1fr) auto;
+  grid-template-rows: minmax(0, 1fr) auto auto;
+  overflow: hidden;
 }
 
 .workspace-main .canvas-panel {
+  min-height: 0;
   padding: 0;
   overflow: hidden;
 }
 
 .workspace-main .graph-stage {
-  min-height: clamp(520px, 72svh, 780px);
+  min-height: 0;
   height: 100%;
   margin-top: 0;
   border: 0;
@@ -347,8 +418,12 @@
 
 .workspace-main .graph-stage .react-flow__controls,
 .workspace-main .graph-stage .react-flow__minimap {
-  background: rgba(247, 251, 255, 0.86);
-  border: 1px solid rgba(23, 49, 82, 0.1);
+  background:
+    linear-gradient(180deg, rgba(225, 236, 248, 0.94), rgba(203, 219, 236, 0.9)),
+    linear-gradient(90deg, rgba(62, 91, 125, 0.12) 1px, transparent 1px),
+    linear-gradient(rgba(62, 91, 125, 0.12) 1px, transparent 1px);
+  background-size: auto, 18px 18px, 18px 18px;
+  border: 1px solid rgba(23, 49, 82, 0.2);
   border-radius: 18px;
   box-shadow: var(--shadow-soft);
 }
@@ -388,8 +463,85 @@
 }
 
 .workspace-main .diagnostics-panel {
+  max-height: min(24svh, 240px);
   padding: 0;
   overflow: hidden;
+}
+
+.source-panel {
+  max-height: min(24svh, 240px);
+  overflow: hidden;
+  border: 1px solid var(--stroke-soft);
+  border-radius: 24px;
+  background: rgba(249, 252, 255, 0.88);
+  box-shadow: var(--shadow-soft);
+}
+
+.source-panel__toggle {
+  width: 100%;
+  border: 0;
+  padding: 16px 18px;
+  background: transparent;
+  color: inherit;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  text-align: left;
+}
+
+.source-panel__toggle span:first-child {
+  display: grid;
+  gap: 4px;
+}
+
+.source-panel__toggle strong {
+  color: var(--ink-strong);
+  font-family: var(--font-display);
+}
+
+.source-panel__toggle em {
+  color: var(--text-soft);
+  font-size: 0.82rem;
+  font-style: normal;
+}
+
+.source-panel__body {
+  display: grid;
+  gap: 12px;
+  min-height: 0;
+  overflow: hidden;
+  border-top: 1px solid var(--stroke-soft);
+  padding: 14px 18px 18px;
+}
+
+.source-panel__alert {
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: var(--warning-soft);
+  color: #8a5b06;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.source-panel__code {
+  max-height: min(14svh, 140px);
+  margin: 0;
+  overflow: auto;
+  padding: 16px;
+  border: 1px solid rgba(23, 49, 82, 0.1);
+  border-radius: 18px;
+  background: #101926;
+  color: #d8e8ff;
+  font-size: 0.85rem;
+  line-height: 1.65;
+  white-space: pre-wrap;
+}
+
+.source-panel__code mark {
+  border-radius: 6px;
+  background: rgba(76, 196, 255, 0.26);
+  color: #f7fbff;
+  outline: 1px solid rgba(76, 196, 255, 0.7);
 }
 
 .diagnostics-panel__toggle {
@@ -421,6 +573,8 @@
 
 .diagnostics-panel__content {
   border-top: 1px solid var(--stroke-soft);
+  max-height: min(16svh, 160px);
+  overflow: auto;
   padding: 0 20px 20px;
 }
 
@@ -430,13 +584,67 @@
 
 .diagnostic-card,
 .inspector-card,
-.inspector-empty-state {
+.inspector-empty-state,
+.metadata-card {
   display: grid;
   gap: 10px;
   padding: 18px;
   background: var(--surface-raised);
   border: 1px solid var(--stroke-soft);
   border-radius: 18px;
+}
+
+.metadata-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+
+.metadata-list dt {
+  color: var(--text-muted);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.metadata-list dd {
+  margin: 0;
+  color: var(--text-soft);
+}
+
+.metadata-subsection {
+  display: grid;
+  gap: 8px;
+}
+
+.metadata-pill-list,
+.metadata-property-list {
+  display: grid;
+  gap: 8px;
+}
+
+.metadata-pill-list li,
+.metadata-property-list li {
+  padding: 10px 12px;
+  border: 1px solid var(--stroke-soft);
+  border-radius: 12px;
+  background: rgba(249, 252, 255, 0.74);
+}
+
+.metadata-property-list li {
+  display: grid;
+  gap: 4px;
+}
+
+.metadata-property-list span {
+  color: var(--ink-strong);
+  font-weight: 700;
+}
+
+.metadata-property-list small {
+  color: var(--text-soft);
+  line-height: 1.45;
 }
 
 .field-label {
@@ -449,6 +657,8 @@
 
 .inspector-panel {
   align-content: start;
+  min-height: 0;
+  overflow: auto;
   padding: 20px;
 }
 
@@ -512,10 +722,15 @@
 @media (max-width: 1180px) {
   .workspace-grid {
     grid-template-columns: 1fr;
+    overflow: auto;
+  }
+
+  .remote-card__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .workspace-main {
-    grid-template-rows: minmax(440px, 1fr) auto;
+    grid-template-rows: minmax(420px, 1fr) auto auto;
   }
 
   .workspace-topbar {
@@ -528,9 +743,62 @@
   }
 }
 
+@media (min-width: 921px) {
+  .launcher-card__header {
+    align-items: end;
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .launcher-card__badges {
+    grid-column: 2;
+    grid-row: 1;
+    justify-content: end;
+  }
+
+  .launcher-card__copy {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .launcher-card__body {
+    align-items: start;
+    grid-template-columns: minmax(0, 1.08fr) minmax(360px, 0.92fr);
+    grid-template-rows: auto auto minmax(0, 1fr);
+  }
+
+  .launcher-card__actions,
+  .launcher-card__paste {
+    grid-column: 1;
+  }
+
+  .launcher-card__body .launcher-divider:nth-child(2) {
+    grid-column: 1;
+  }
+
+  .launcher-card__body .launcher-divider:nth-child(4) {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .remote-card {
+    grid-column: 2;
+    grid-row: 2 / span 2;
+  }
+
+  .remote-card__grid {
+    grid-template-columns: minmax(150px, 1.2fr) minmax(86px, 0.58fr);
+  }
+}
+
 @media (max-width: 720px) {
   .app-shell {
     padding: 12px;
+  }
+
+  .app-shell--home {
+    height: auto;
+    min-height: 100svh;
+    overflow: visible;
   }
 
   .home-screen--focused {
@@ -541,6 +809,10 @@
   .workspace-topbar,
   .inspector-panel {
     padding: 18px;
+  }
+
+  .launcher-card {
+    max-height: none;
   }
 
   .launcher-card h1,
@@ -557,7 +829,16 @@
     grid-template-columns: 1fr;
   }
 
+  .remote-card__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .workspace-alert,
+  .source-panel__toggle {
+    flex-direction: column;
+  }
+
   .workspace-main .graph-stage {
-    min-height: 420px;
+    min-height: 360px;
   }
 }

--- a/src/styles/graph.css
+++ b/src/styles/graph.css
@@ -28,10 +28,34 @@
 
 .graph-stage .react-flow__controls,
 .graph-stage .react-flow__minimap {
-  background: rgba(255, 255, 255, 0.82);
-  border: 1px solid var(--stroke-soft);
+  background:
+    linear-gradient(180deg, rgba(225, 236, 248, 0.94), rgba(203, 219, 236, 0.9)),
+    linear-gradient(90deg, rgba(62, 91, 125, 0.12) 1px, transparent 1px),
+    linear-gradient(rgba(62, 91, 125, 0.12) 1px, transparent 1px);
+  background-size: auto, 18px 18px, 18px 18px;
+  border: 1px solid rgba(23, 49, 82, 0.2);
   border-radius: 18px;
   box-shadow: var(--shadow-soft);
+}
+
+.graph-stage .react-flow__minimap {
+  overflow: hidden;
+  width: 220px;
+  height: 150px;
+}
+
+.graph-stage .react-flow__minimap svg {
+  background: transparent;
+}
+
+.graph-stage .react-flow__minimap-mask {
+  fill: rgba(14, 27, 43, 0.18) !important;
+}
+
+.graph-stage .react-flow__minimap-node {
+  stroke: rgba(6, 24, 48, 0.72);
+  stroke-width: 2.4;
+  vector-effect: non-scaling-stroke;
 }
 
 .graph-stage .react-flow__controls-button {
@@ -41,7 +65,9 @@
 }
 
 .graph-stage .react-flow__edge-textbg {
-  fill: rgba(247, 249, 252, 0.9);
+  fill: rgba(247, 250, 253, 0.96);
+  stroke: rgba(23, 49, 82, 0.12);
+  stroke-width: 1;
 }
 
 .graph-badge {
@@ -54,8 +80,21 @@
   font-weight: 600;
 }
 
+.graph-inline-action {
+  border: 0;
+  border-radius: 999px;
+  padding: 5px 8px;
+  background: rgba(21, 141, 255, 0.12);
+  color: var(--accent-primary);
+  font-size: 0.74rem;
+  font-weight: 800;
+}
+
 .technical-node {
+  position: relative;
+  box-sizing: border-box;
   min-width: 220px;
+  height: 100%;
   display: grid;
   gap: 8px;
   padding: 14px;
@@ -81,6 +120,7 @@
 
 .technical-node__eyebrow {
   display: flex;
+  align-items: center;
   justify-content: space-between;
   gap: 10px;
   color: var(--text-muted);
@@ -88,6 +128,21 @@
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+.technical-node__drag-handle {
+  margin-left: auto;
+  padding: 2px 6px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.46);
+  color: rgba(22, 37, 58, 0.42);
+  cursor: grab;
+  font-family: var(--font-display);
+  letter-spacing: -0.16em;
+}
+
+.technical-node__drag-handle:active {
+  cursor: grabbing;
 }
 
 .technical-node__tags span {
@@ -103,6 +158,30 @@
   height: 10px;
   background: rgba(22, 37, 58, 0.35);
   border: 2px solid rgba(255, 255, 255, 0.84);
+}
+
+.technical-node__port-label {
+  position: absolute;
+  top: 50%;
+  z-index: 2;
+  padding: 3px 6px;
+  border: 1px solid rgba(23, 49, 82, 0.12);
+  border-radius: 999px;
+  background: rgba(247, 251, 255, 0.86);
+  color: rgba(22, 37, 58, 0.58);
+  font-size: 0.58rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
+.technical-node__port-label--sink {
+  left: -18px;
+}
+
+.technical-node__port-label--src {
+  right: -14px;
 }
 
 .technical-node.is-selected {
@@ -134,5 +213,5 @@
 }
 
 .graph-minimap {
-  overflow: hidden;
+  color: var(--minimap-node);
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -41,7 +41,7 @@
   --tone-unknown: #e7edf4;
   --edge-muted: #8ca1b9;
   --edge-active: #158dff;
-  --minimap-node: rgba(21, 141, 255, 0.72);
+  --minimap-node: rgba(15, 86, 156, 0.9);
   --font-display: 'Avenir Next Condensed', 'Avenir Next', 'Trebuchet MS', sans-serif;
   --font-body: 'Aptos', 'Segoe UI', sans-serif;
   --font-mono: 'JetBrains Mono', 'SFMono-Regular', monospace;


### PR DESCRIPTION
## 요약

Sprint 03 범위의 GStreamer Topology MVP 기능 구현과 사용자 QA 재작업을 마무리했습니다.

주요 변경:
- 로컬 GStreamer `gst-inspect-1.0` 기반 Element metadata 조회 및 인스펙터 표시
- Pipeline 원문 패널과 선택 Element source span 하이라이트
- React Flow node 위치 이동, localStorage 기반 위치 유지, 레이아웃 초기화
- 파서 진단 경고/진단 패널 UX 보강
- Remote OE-Linux SSH/SFTP probe/load 및 remote metadata 1차 경로
- `tee`, `compositor`, named/request pad parser hardening
- MiniMap node visibility와 첫 화면 레이아웃 재작업
- GitHub sprint/agent process 문서화 및 `Atlas/Forge/Loom/Beacon` alias 추가

## 사용자 QA 결과

Sprint 03 사용자 QA 결과, `#1~#12`는 Done 상태로 확인했습니다.

재작업 완료 항목:
- #2 `04_compositor_named_pad.pld` compositor/named-pad flow
- #4 MiniMap node visibility
- #5 첫 화면 레이아웃 비율

Sprint 04 후보로 분리한 항목:
- #14 긴 RTF Pipeline에서 원문 하이라이트 누락 수정

## 검증

- `npm run lint`: 통과
- `npm run build`: 통과
- `cd src-tauri && cargo test`: 통과, 4 tests passed
- `npm run tauri:dev`: native app process 확인
- Native 앱에서 `04_compositor_named_pad.pld` 열기 확인: `노드 7개 / 엣지 6개`, `mix`, `SRC -> SINK sink_1` 확인
- Native 앱에서 `02_videotestsrc_tee_branch.pld` 열기 경로 확인

참고: Vite build에서 기존 chunk size warning은 계속 표시됩니다.

## 미검증 / 다음 스프린트

- 실제 OE-Linux target SSH/SFTP 및 remote `gst-inspect-1.0` 검증은 아직 미검증입니다.
- 긴 RTF fixture의 source span highlight 안정화는 Sprint 04 후보 `#14`로 분리했습니다.
- Remote Server modal/icon 기반 진입 UX는 Sprint 04 후보 `#13`으로 유지합니다.