### PR TITLE
Sprint 04 UI/UX and source highlight improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,23 @@ If there is a conflict:
 - `docs/PROCESS_POLICY.md` governs execution, verification, and handoff
 - The remaining docs govern scope, architecture, and delivery order
 
+## External Coding Guideline
+
+Before substantial feature implementation, also consult the Karpathy Guidelines:
+
+- https://github.com/forrestchang/andrej-karpathy-skills/blob/main/skills/karpathy-guidelines/SKILL.md
+
+Apply the guideline as a coding discipline:
+- Think before coding: state assumptions, ambiguity, and tradeoffs.
+- Prefer simplicity: implement the minimum code that solves the requested
+  behavior.
+- Make surgical changes: avoid unrelated refactors and only clean up issues
+  created by the current change.
+- Define verifiable success: pair each implementation step with concrete checks.
+
+If the guideline conflicts with a direct user request or this repository's
+process policy, the user request and `docs/PROCESS_POLICY.md` still win.
+
 ## Locked Decisions
 
 These decisions are already made unless the user explicitly changes them:

--- a/docs/GITHUB_PROJECTS.md
+++ b/docs/GITHUB_PROJECTS.md
@@ -3,14 +3,23 @@
 이 문서는 `GStreamer Topology`를 GitHub Issues와 GitHub Projects로 운영하기 위한
 칸반 보드 기준입니다.
 
-## 권장 보드
+## 권장 보드 구조
 
-보드 이름:
+상위 보드:
 - `GStreamer Topology Sprint Board`
 
-보드 목적:
-- 요청사항을 작은 카드로 쪼개고, `기획 -> 개발 -> 디자인 -> QA -> 완료` 흐름을
-  한 곳에서 추적한다.
+상위 보드 목적:
+- 전체 백로그, 이전 스프린트 히스토리, 다음 스프린트 후보, 크로스 스프린트
+  흐름을 한 곳에서 추적한다.
+
+스프린트 실행 보드:
+- `Sprint 04`
+- `Sprint 05`
+- 이후 동일한 이름 규칙 사용
+
+스프린트 실행 보드 목적:
+- 해당 스프린트에서 실제로 처리할 이슈만 넣고, 사용자가 `Todo`,
+  `In Progress`, `Done` 기준으로 구현/QA 상태를 확인한다.
 
 ## 컬럼
 
@@ -41,28 +50,28 @@
 - `Done`으로 이동하려면 검증 결과와 남은 미검증 범위를 명시한다.
 - `tauri:dev`는 네이티브 창이 실제로 뜨거나 native process가 살아 있음을 확인해야 검증 완료로 본다.
 
-## 스프린트 View 운영 규칙
+## 스프린트 Project 운영 규칙
 
 사용자가 `Sprint NN 준비를 시작하자`고 말하면 아래 상태까지 정리한다.
 
-- GitHub Project에 새 View를 만들고 이름을 `Sprint NN`으로 지정한다.
-- 해당 Sprint에서 다룰 이슈에 `sprint-NN` 라벨 또는 Sprint 필드를 적용한다.
-- 새 View는 `sprint-NN` 라벨 또는 Sprint 필드로 필터링해, 해당 Sprint 이슈만 관리하기 쉽게 만든다.
+- `Sprint NN` 이름의 새 GitHub Project를 만든다.
+- 새 Project를 `GStreamer-Topology` repository에 연결한다.
+- 해당 Sprint에서 다룰 이슈에 `sprint-NN` 라벨을 적용한다.
+- 해당 이슈를 상위 보드와 `Sprint NN` Project 양쪽에 추가한다.
 - Sprint 시작 시점의 기능 후보 이슈는 `Todo`에 둔다.
 - 바로 구현을 시작할 첫 번째 이슈만 `In Progress`로 옮긴다.
-- 사용자가 이후 기능 요청사항을 주면, 그 요청을 이 View 안에서 새 이슈 또는 기존 이슈 보강 형태로 정리한다.
+- 사용자가 이후 기능 요청사항을 주면, 그 요청을 `Sprint NN` Project 안에서
+  새 이슈 또는 기존 이슈 보강 형태로 정리한다.
 
-GitHub Projects의 View는 이슈가 물리적으로 이동되는 별도 저장소가 아니라
-Project item을 보는 보드/필터에 가깝다. 따라서 Agent는 View 생성과 함께
-라벨, Sprint 필드, Status 값을 맞춰 사용자가 해당 View에서 이슈를 관리할 수
-있게 해야 한다.
+이 구조에서 상위 보드는 전체 프로젝트 관리용이고, `Sprint NN` Project는 해당
+스프린트의 실행/QA 관리용이다.
 
-현재 GitHub CLI/API에서 Project View 생성 또는 이름 변경이 지원되지 않는
-환경이면, Agent는 이 단계를 조용히 생략하지 않는다.
+GitHub CLI/API에서 Project 생성 또는 repo 연결이 실패하면 Agent는 이 단계를
+조용히 생략하지 않는다.
 
-- 원하는 View 이름을 명시한다.
-- 사용자가 GitHub 웹 UI에서 View를 만들거나 이름을 바꿔야 한다고 알린다.
-- 그동안 가능한 작업인 이슈 본문, 라벨, Project Status, 코멘트 정리는 완료한다.
+- 원하는 Project 이름을 명시한다.
+- 실패한 명령과 원인을 기록한다.
+- 가능한 작업인 이슈 본문, 라벨, 상위 보드 Status, 코멘트 정리는 완료한다.
 
 ## 스프린트 카드 기준
 
@@ -104,6 +113,14 @@ gh project list --owner slayellow
 
 ```bash
 gh project link <PROJECT_NUMBER> --owner slayellow --repo GStreamer-Topology
+```
+
+스프린트 실행 보드도 같은 방식으로 만든다.
+
+```bash
+gh project create --owner slayellow --title "Sprint 04"
+gh project link <SPRINT_PROJECT_NUMBER> --owner slayellow --repo GStreamer-Topology
+gh project item-add <SPRINT_PROJECT_NUMBER> --owner slayellow --url <ISSUE_URL>
 ```
 
 필드는 GitHub UI에서 직접 추가하는 편이 가장 안전하다. 프로젝트를 만든 뒤

--- a/docs/GITHUB_PROJECTS.md
+++ b/docs/GITHUB_PROJECTS.md
@@ -41,6 +41,29 @@
 - `Done`으로 이동하려면 검증 결과와 남은 미검증 범위를 명시한다.
 - `tauri:dev`는 네이티브 창이 실제로 뜨거나 native process가 살아 있음을 확인해야 검증 완료로 본다.
 
+## 스프린트 View 운영 규칙
+
+사용자가 `Sprint NN 준비를 시작하자`고 말하면 아래 상태까지 정리한다.
+
+- GitHub Project에 새 View를 만들고 이름을 `Sprint NN`으로 지정한다.
+- 해당 Sprint에서 다룰 이슈에 `sprint-NN` 라벨 또는 Sprint 필드를 적용한다.
+- 새 View는 `sprint-NN` 라벨 또는 Sprint 필드로 필터링해, 해당 Sprint 이슈만 관리하기 쉽게 만든다.
+- Sprint 시작 시점의 기능 후보 이슈는 `Todo`에 둔다.
+- 바로 구현을 시작할 첫 번째 이슈만 `In Progress`로 옮긴다.
+- 사용자가 이후 기능 요청사항을 주면, 그 요청을 이 View 안에서 새 이슈 또는 기존 이슈 보강 형태로 정리한다.
+
+GitHub Projects의 View는 이슈가 물리적으로 이동되는 별도 저장소가 아니라
+Project item을 보는 보드/필터에 가깝다. 따라서 Agent는 View 생성과 함께
+라벨, Sprint 필드, Status 값을 맞춰 사용자가 해당 View에서 이슈를 관리할 수
+있게 해야 한다.
+
+현재 GitHub CLI/API에서 Project View 생성 또는 이름 변경이 지원되지 않는
+환경이면, Agent는 이 단계를 조용히 생략하지 않는다.
+
+- 원하는 View 이름을 명시한다.
+- 사용자가 GitHub 웹 UI에서 View를 만들거나 이름을 바꿔야 한다고 알린다.
+- 그동안 가능한 작업인 이슈 본문, 라벨, Project Status, 코멘트 정리는 완료한다.
+
 ## 스프린트 카드 기준
 
 카드 하나는 가능한 한 하나의 사용자 가치를 담아야 한다.

--- a/docs/PROCESS_POLICY.md
+++ b/docs/PROCESS_POLICY.md
@@ -31,16 +31,21 @@ Use GitHub as the sprint source of truth before substantial implementation.
 Sprint setup:
 - When the user says to start preparing a new sprint, treat that as a board
   setup request, not only as a branch setup request.
-- Create a new GitHub Project view named after the active sprint, such as
+- Keep `GStreamer Topology Sprint Board` as the parent board for the full
+  backlog, history, and cross-sprint visibility.
+- Create a new GitHub Project named after the active sprint, such as
   `Sprint 04`, before implementation starts.
-- Configure the sprint view so the active sprint issues are visible there.
-  Prefer a sprint label or sprint field filter, such as `sprint-04`.
-- Move or prepare the relevant sprint issues, such as `#13` and `#14`, so the
-  user can manage them from that sprint view.
-- If the GitHub API/CLI cannot create or rename Project views, do not silently
-  skip the step. Record the desired view name in the handoff, ask the user to
-  create or rename the view in the GitHub web UI, and still apply the sprint
-  labels/statuses needed for the issues to appear in that view.
+- Link the sprint Project to the `GStreamer-Topology` repository so it appears
+  from the repository's `Projects` tab.
+- Add the active sprint issues, such as `#13` and `#14`, to both the parent
+  board and the sprint-specific Project.
+- Set the sprint-specific Project status so the user can manage that sprint
+  with `Todo`, `In Progress`, and `Done`.
+- Add sprint labels such as `sprint-04` so the same issues remain traceable from
+  the parent board.
+- If GitHub Project creation or repository linking fails, do not silently skip
+  the step. Record the intended Project name, what failed, and what issue
+  labels/statuses were still applied.
 - Create one GitHub Issue per independently testable feature or bug.
 - Write issue titles and descriptions in Korean by default.
 - Use English only for code identifiers, commands, file paths, APIs, and
@@ -69,18 +74,18 @@ Sprint closeout:
 - Move completed issues to `Done` only after code is committed, pushed, and the
   user-visible QA path has passed.
 - The user is expected to inspect `In Progress` issues in the active sprint
-  view, run the checklist in each issue, move passing issues to `Done`, and
+  Project, run the checklist in each issue, move passing issues to `Done`, and
   leave comments on issues that fail.
 - After user QA, review the user's comments and classify each finding as either
   same-sprint rework or next-sprint backlog.
 - Same-sprint rework should be fixed on the active sprint branch and returned
   to the user for another QA pass.
 - Next-sprint backlog should be captured as a new issue or moved into the next
-  sprint view.
+  sprint Project.
 - If an issue is only partially implemented, leave it `In Progress` or move the
   remaining work into the next sprint issue.
 - If a bug is discovered during user QA, create or move a follow-up issue into
-  the next sprint view, such as `Sprint 04`.
+  the next sprint Project, such as `Sprint 04`.
 
 ## Required Expert Subagent Loop
 

--- a/docs/PROCESS_POLICY.md
+++ b/docs/PROCESS_POLICY.md
@@ -8,6 +8,12 @@ Read this file before starting feature work.
 ## Core Rules
 
 - Work in thin slices with one coherent user-visible outcome.
+- Before substantial feature implementation, consult the Karpathy Guidelines
+  reference requested by the user:
+  `https://github.com/forrestchang/andrej-karpathy-skills/blob/main/skills/karpathy-guidelines/SKILL.md`.
+- Apply the Karpathy Guidelines as execution discipline: surface assumptions,
+  choose the simplest sufficient solution, avoid speculative abstractions,
+  make surgical changes only, and define verifiable success criteria.
 - Anchor every task to the current source of truth in this order:
   `docs/PRD.md`, `docs/ARCHITECTURE.md`, `docs/IMPLEMENTATION_PLAN.md`,
   `docs/REPOSITORY_STRUCTURE.md`, `docs/TECH_SPIKES.md`.

--- a/docs/PROCESS_POLICY.md
+++ b/docs/PROCESS_POLICY.md
@@ -29,11 +29,18 @@ Read this file before starting feature work.
 Use GitHub as the sprint source of truth before substantial implementation.
 
 Sprint setup:
-- Create or update a GitHub Project view named after the active sprint, such as
-  `Sprint 03`.
-- If the GitHub API/CLI cannot create or rename Project views, record the
-  desired view name in the handoff and ask the user to rename it in the GitHub
-  web UI.
+- When the user says to start preparing a new sprint, treat that as a board
+  setup request, not only as a branch setup request.
+- Create a new GitHub Project view named after the active sprint, such as
+  `Sprint 04`, before implementation starts.
+- Configure the sprint view so the active sprint issues are visible there.
+  Prefer a sprint label or sprint field filter, such as `sprint-04`.
+- Move or prepare the relevant sprint issues, such as `#13` and `#14`, so the
+  user can manage them from that sprint view.
+- If the GitHub API/CLI cannot create or rename Project views, do not silently
+  skip the step. Record the desired view name in the handoff, ask the user to
+  create or rename the view in the GitHub web UI, and still apply the sprint
+  labels/statuses needed for the issues to appear in that view.
 - Create one GitHub Issue per independently testable feature or bug.
 - Write issue titles and descriptions in Korean by default.
 - Use English only for code identifiers, commands, file paths, APIs, and

--- a/docs/SPRINT_04_PREP.md
+++ b/docs/SPRINT_04_PREP.md
@@ -1,0 +1,176 @@
+# Sprint 04 Preparation
+
+Date: 2026-04-26
+
+Branch:
+- `sprint_04`
+
+Base:
+- `main` after Sprint 03 merge commit `aa75c23`
+
+## Sprint Goal
+
+Stabilize the topology verification workflow for real user files by making long
+RTF source highlighting reliable, then simplify the Local/Remote entry
+experience so Remote Server access is clearly separated from the local pipeline
+workflow.
+
+## Sprint Board Items
+
+Primary implementation order:
+
+1. `#14` `스프린트 04: 긴 RTF Pipeline 원문 하이라이트 안정화`
+2. `#13` `스프린트 04: Local/Remote 진입 UX와 Remote Server 접속 모달 재설계`
+
+Rationale:
+- `#14` comes first because source-span highlighting is the trust layer between
+  the rendered topology and the original pipeline text.
+- `#13` comes second because the Remote Server UX is broader and should not
+  distract from fixing the user-reported Sprint 03 regression.
+
+GitHub Project note:
+- GitHub CLI and the currently available GraphQL mutations can update issues,
+  labels, comments, and project item status.
+- They do not expose a safe project view create/rename mutation in this
+  environment.
+- If a dedicated Project View is needed, create or rename it in the GitHub web
+  UI as `Sprint 04`.
+
+## Expert Loop
+
+Use the stable aliases defined in `AGENTS.md` and `docs/PROCESS_POLICY.md`.
+
+- `Atlas`: planner
+- `Forge`: developer
+- `Loom`: designer
+- `Beacon`: QA
+
+### Atlas Planning Summary
+
+Goal:
+- Make the user able to trust graph-to-source navigation on long RTF files, then
+  clarify the Local/Remote entry flow.
+
+Smallest useful slices:
+- Add regression coverage that validates source spans for
+  `26_release_record_smoothing.pld.rtf` and `27_pipmux.pld.rtf`.
+- Fix source-panel highlighting and scrolling for long normalized text.
+- Redesign the home entry so Local remains the default and Remote Server opens
+  from a separate modal.
+
+Stop conditions:
+- Stop if source-span mapping cannot be preserved with fixture evidence.
+- Stop if Remote Server work requires write access to the target or plaintext
+  credential persistence.
+- Mark real remote behavior as unverified unless tested against a real
+  `OE-Linux` target or a controlled test target.
+
+### Forge Implementation Summary
+
+Likely files for `#14`:
+- `src/features/workspace/SourceTextPanel.tsx`
+- `src/features/workspace/WorkspaceShell.tsx`
+- `src/graph/fromBackend.ts`
+- `src-tauri/src/parser/pipeline.rs`
+
+Likely files for `#13`:
+- `src/features/home/HomeScreen.tsx`
+- `src/app/AppShell.tsx`
+- `src/app/backend.ts`
+- `src/styles/app-shell.css`
+
+Implementation order:
+- Start with backend parser/source-span regression tests for long RTF fixtures.
+- Then fix frontend span validation, highlight rendering, and source-panel
+  scroll/focus behavior.
+- After `#14` passes, split Remote Server UX into a modal-oriented UI slice.
+
+Risks:
+- Rust spans are byte offsets, while JavaScript string slicing uses UTF-16 code
+  units. Conversion must be handled deliberately if non-ASCII text is involved.
+- Nested scroll containers can make `scrollIntoView` appear unreliable unless
+  the highlighted target and panel container are controlled.
+- Actual Remote Server success cannot be fully verified without an `OE-Linux`
+  target.
+
+### Loom Design Summary
+
+Design direction:
+- Keep the Technical Canvas direction: calm off-white workspace, clear blue
+  selection state, compact desktop chrome, low visual noise.
+
+For `#14`:
+- When an element is selected, the `Pipeline 원문` panel should visibly move to
+  the selected span.
+- If the source position cannot be found, show an explicit recoverable warning
+  instead of silently failing.
+- Show the currently selected element near the source panel so users can tell
+  what the highlight represents.
+
+For `#13`:
+- Keep Local as the default path.
+- Move Remote Server inputs out of the main home layout into a focused modal.
+- Use copy that makes the Remote Server role clear: read GStreamer metadata
+  from the target device, not general fleet management.
+
+### Beacon QA Summary
+
+Required automated checks:
+- `npm run lint`
+- `npm run build`
+- `cd src-tauri && cargo test`
+- `npm run tauri:dev`
+
+`tauri:dev` rule:
+- It only counts as verified when the native Tauri window launches, or the
+  native app process is confirmed alive without immediately crashing.
+
+User-visible checks for `#14`:
+- Open `26_release_record_smoothing.pld.rtf`.
+- Open `Pipeline 원문`.
+- Click several elements and confirm the source highlight is visible and moves.
+- Repeat with `27_pipmux.pld.rtf`.
+- Record fixture name, clicked element, and panel state for any missing
+  highlight.
+
+User-visible checks for `#13`:
+- Confirm the first screen clearly separates Local and Remote Server.
+- Open the Remote Server modal.
+- Enter invalid connection data and confirm the failure is understandable.
+- Confirm the Local file and paste flows still work after failed remote access.
+
+Unverified until a real target is available:
+- `OE-Linux` SSH authentication
+- SFTP remote read/listing
+- remote `gst-inspect-1.0` metadata parsing
+- Windows/Linux packaging and native WebView behavior
+
+## Acceptance Criteria
+
+For `#14`:
+- `26_release_record_smoothing.pld.rtf` and `27_pipmux.pld.rtf` parse without
+  source-span bounds regressions.
+- Selected graph nodes with source spans highlight the corresponding normalized
+  source text.
+- Long source text scrolls or focuses to the selected highlight.
+- Highlight failure is shown as a recoverable diagnostic, not a silent miss.
+- Existing short fixtures `01` to `04` keep their source-view behavior.
+
+For `#13`:
+- Local file open and pasted-text topology generation remain the primary first
+  screen actions.
+- Remote Server connection opens in a modal/dialog instead of occupying the
+  default home layout.
+- Invalid remote connection attempts show a clear failure state.
+- Failed remote attempts do not destroy or block the Local workflow.
+- UI copy remains Korean except code identifiers, commands, file paths, APIs,
+  and GStreamer syntax.
+
+## Handoff Rule For Sprint 04
+
+Before handing work to the user for QA:
+- Update the relevant GitHub issue body with current implementation status.
+- Post `Beacon` expert QA results as a Korean comment on the issue.
+- Move the issue to `In Progress` while implementation or user QA is active.
+- Move the issue to `Done` only after user QA passes.
+- Record any user-reported failure as same-sprint rework or next-sprint backlog.

--- a/docs/SPRINT_04_PREP.md
+++ b/docs/SPRINT_04_PREP.md
@@ -19,14 +19,20 @@ workflow.
 
 Primary implementation order:
 
-1. `#14` `스프린트 04: 긴 RTF Pipeline 원문 하이라이트 안정화`
-2. `#13` `스프린트 04: Local/Remote 진입 UX와 Remote Server 접속 모달 재설계`
+1. `#16` `스프린트 04: 파일 가져오기 미리보기와 토폴로지 생성 단계 분리`
+2. `#17` `스프린트 04: 아이콘 중심 캔버스 툴바와 보조 패널 Drawer 전환`
+3. `#13` `스프린트 04: Local/Remote 진입 UX와 Remote Server 접속 모달 재설계`
+4. `#14` `스프린트 04: 긴 RTF Pipeline 원문 하이라이트 안정화`
 
 Rationale:
-- `#14` comes first because source-span highlighting is the trust layer between
-  the rendered topology and the original pipeline text.
-- `#13` comes second because the Remote Server UX is broader and should not
-  distract from fixing the user-reported Sprint 03 regression.
+- `#16` comes first because file import no longer goes directly to canvas; the
+  new preview/edit step defines how users enter the workspace.
+- `#17` comes second because the workspace is now canvas-first with icon-driven
+  drawers for inspector, source text, and parser diagnostics.
+- `#13` follows the new shell structure with Remote Server status badges and a
+  modal-based remote connection flow.
+- `#14` remains in the sprint, but source highlighting should be finalized on
+  top of the new source drawer interaction.
 
 GitHub Project note:
 - Parent board: `GStreamer Topology Sprint Board`
@@ -35,9 +41,13 @@ GitHub Project note:
 - The `Sprint 04` Project is linked to the `GStreamer-Topology` repository.
 - Issues `#13` and `#14` are added to both the parent board and the `Sprint 04`
   Project.
+- Issues `#16` and `#17` were added after the Sprint 04 UI/UX requirements were
+  refined.
 - Current `Sprint 04` Project state:
-  - `#14` is `In Progress`
-  - `#13` is `Todo`
+  - `#16` is `In Progress`
+  - `#17` is `In Progress`
+  - `#13` is `In Progress`
+  - `#14` is `Todo`
 
 ## Expert Loop
 
@@ -55,6 +65,11 @@ Goal:
   clarify the Local/Remote entry flow.
 
 Smallest useful slices:
+- Add a file import preview/edit screen before workspace navigation.
+- Move workspace support panels into icon-triggered drawers so the canvas is
+  maximized by default.
+- Surface GStreamer API and Remote Server connection status through status
+  badges.
 - Add regression coverage that validates source spans for
   `26_release_record_smoothing.pld.rtf` and `27_pipmux.pld.rtf`.
 - Fix source-panel highlighting and scrolling for long normalized text.
@@ -76,6 +91,17 @@ Likely files for `#14`:
 - `src/graph/fromBackend.ts`
 - `src-tauri/src/parser/pipeline.rs`
 
+Likely files for `#16` and `#17`:
+- `src/app/AppShell.tsx`
+- `src/app/status.ts`
+- `src/components/Icon.tsx`
+- `src/components/IconButton.tsx`
+- `src/components/ConnectionBadge.tsx`
+- `src/features/import-preview/ImportPreviewScreen.tsx`
+- `src/features/home/HomeScreen.tsx`
+- `src/features/workspace/WorkspaceShell.tsx`
+- `src/styles/app-shell.css`
+
 Likely files for `#13`:
 - `src/features/home/HomeScreen.tsx`
 - `src/app/AppShell.tsx`
@@ -83,10 +109,14 @@ Likely files for `#13`:
 - `src/styles/app-shell.css`
 
 Implementation order:
-- Start with backend parser/source-span regression tests for long RTF fixtures.
-- Then fix frontend span validation, highlight rendering, and source-panel
-  scroll/focus behavior.
-- After `#14` passes, split Remote Server UX into a modal-oriented UI slice.
+- Start with the import preview/edit screen and reuse parsed preview text for
+  final topology generation.
+- Then switch workspace panels to icon-triggered drawers and keep the canvas
+  full-width by default.
+- Add GStreamer API and Remote Server status badges across home, preview, and
+  workspace.
+- Finish long RTF source highlight reliability after the source panel lives in
+  the drawer.
 
 Risks:
 - Rust spans are byte offsets, while JavaScript string slicing uses UTF-16 code
@@ -116,6 +146,13 @@ For `#13`:
 - Use copy that makes the Remote Server role clear: read GStreamer metadata
   from the target device, not general fleet management.
 
+For `#16` and `#17`:
+- Show a `파일 미리보기` step before opening the workspace.
+- Keep workspace support tools as icon actions in the top-right area.
+- Default the workspace to canvas-first, with drawers opening only on demand.
+- Ensure icon-only controls still have labels, tooltips, and keyboard focus
+  feedback.
+
 ### Beacon QA Summary
 
 Required automated checks:
@@ -141,6 +178,16 @@ User-visible checks for `#13`:
 - Open the Remote Server modal.
 - Enter invalid connection data and confirm the failure is understandable.
 - Confirm the Local file and paste flows still work after failed remote access.
+
+User-visible checks for `#16` and `#17`:
+- Select a local file and confirm the app opens `파일 미리보기`, not the
+  workspace.
+- Edit preview text and confirm `토폴로지 생성` uses the edited text.
+- Confirm the workspace opens with inspector/source/diagnostics hidden by
+  default.
+- Use the top-right icons to open and close inspector, source text, and parser
+  diagnostics.
+- Confirm icon controls show focus outlines and useful labels/tooltips.
 
 Unverified until a real target is available:
 - `OE-Linux` SSH authentication
@@ -168,6 +215,15 @@ For `#13`:
 - Failed remote attempts do not destroy or block the Local workflow.
 - UI copy remains Korean except code identifiers, commands, file paths, APIs,
   and GStreamer syntax.
+
+For `#16` and `#17`:
+- File selection opens a preview/edit screen before workspace navigation.
+- The preview screen displays normalized pipeline text for RTF-backed files.
+- Workspace opens with the topology canvas as the dominant view.
+- Inspector, source text, and parser diagnostics are hidden by default and can
+  be toggled from top-right icons.
+- Icon-only controls provide accessible labels, title tooltips, and focus
+  states.
 
 ## Handoff Rule For Sprint 04
 

--- a/docs/SPRINT_04_PREP.md
+++ b/docs/SPRINT_04_PREP.md
@@ -33,8 +33,12 @@ GitHub Project note:
   labels, comments, and project item status.
 - They do not expose a safe project view create/rename mutation in this
   environment.
-- If a dedicated Project View is needed, create or rename it in the GitHub web
-  UI as `Sprint 04`.
+- Target board state for Sprint 04 is a dedicated GitHub Project View named
+  `Sprint 04`.
+- Because the available CLI/API cannot create or rename Project views, create
+  or rename the View in the GitHub web UI as `Sprint 04`.
+- Issues `#13` and `#14` already have the `sprint-04` label so they can appear
+  in that View when it is filtered by the active sprint.
 
 ## Expert Loop
 

--- a/docs/SPRINT_04_PREP.md
+++ b/docs/SPRINT_04_PREP.md
@@ -29,16 +29,15 @@ Rationale:
   distract from fixing the user-reported Sprint 03 regression.
 
 GitHub Project note:
-- GitHub CLI and the currently available GraphQL mutations can update issues,
-  labels, comments, and project item status.
-- They do not expose a safe project view create/rename mutation in this
-  environment.
-- Target board state for Sprint 04 is a dedicated GitHub Project View named
-  `Sprint 04`.
-- Because the available CLI/API cannot create or rename Project views, create
-  or rename the View in the GitHub web UI as `Sprint 04`.
-- Issues `#13` and `#14` already have the `sprint-04` label so they can appear
-  in that View when it is filtered by the active sprint.
+- Parent board: `GStreamer Topology Sprint Board`
+- Sprint execution board: `Sprint 04`
+- Project URL: `https://github.com/users/slayellow/projects/2`
+- The `Sprint 04` Project is linked to the `GStreamer-Topology` repository.
+- Issues `#13` and `#14` are added to both the parent board and the `Sprint 04`
+  Project.
+- Current `Sprint 04` Project state:
+  - `#14` is `In Progress`
+  - `#13` is `Todo`
 
 ## Expert Loop
 

--- a/src-tauri/src/parser/pipeline.rs
+++ b/src-tauri/src/parser/pipeline.rs
@@ -681,7 +681,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::parse_graph;
-    use crate::models::PipelinePortKind;
+    use crate::models::{PipelinePortKind, SourceSpan};
     use crate::parser::normalize_text;
 
     fn repo_root() -> PathBuf {
@@ -689,6 +689,26 @@ mod tests {
             .parent()
             .expect("src-tauri should live under the repo root")
             .to_path_buf()
+    }
+
+    fn assert_span_inside_text(sample_name: &str, label: &str, text: &str, span: &SourceSpan) {
+        assert!(
+            span.start < span.end,
+            "{label} in {sample_name} has an empty source span: {span:?}"
+        );
+        assert!(
+            span.end <= text.len(),
+            "{label} in {sample_name} has an out-of-range source span {span:?} for text length {}",
+            text.len()
+        );
+        assert!(
+            text.is_char_boundary(span.start) && text.is_char_boundary(span.end),
+            "{label} in {sample_name} source span is not on UTF-8 boundaries: {span:?}"
+        );
+        assert!(
+            !text[span.start..span.end].trim().is_empty(),
+            "{label} in {sample_name} highlights only whitespace"
+        );
     }
 
     #[test]
@@ -746,6 +766,74 @@ mod tests {
                 }),
                 "expected named source pads such as src_1 from sample {sample_name}"
             );
+        }
+    }
+
+    #[test]
+    fn sample_rtf_node_spans_stay_inside_normalized_text() {
+        for sample_name in ["26_release_record_smoothing.pld.rtf", "27_pipmux.pld.rtf"] {
+            let sample_path = repo_root().join(sample_name);
+            let raw = fs::read_to_string(sample_path).expect("sample fixture should exist");
+            let normalized = normalize_text(&raw);
+            let text = normalized.normalized_text;
+            let (graph, _) = parse_graph(&text);
+
+            assert!(
+                !graph.nodes.is_empty(),
+                "expected nodes from sample {sample_name}"
+            );
+
+            for node in &graph.nodes {
+                let label = format!("node {}", node.id);
+                assert_span_inside_text(sample_name, &label, &text, &node.source_span);
+                assert!(
+                    text[node.source_span.start..node.source_span.end]
+                        .contains(&node.factory_name),
+                    "node {} in {sample_name} source span should include factory `{}`",
+                    node.id,
+                    node.factory_name
+                );
+            }
+
+            for edge in &graph.edges {
+                let label = format!("edge {}", edge.id);
+                assert_span_inside_text(sample_name, &label, &text, &edge.source_span);
+            }
+        }
+    }
+
+    #[test]
+    fn short_fixture_node_and_edge_spans_stay_inside_normalized_text() {
+        for sample_name in [
+            "fixtures/pipelines/01_videotestsrc_linear.pld",
+            "fixtures/pipelines/02_videotestsrc_tee_branch.pld",
+            "fixtures/pipelines/03_audiotestsrc_basic.pld",
+            "fixtures/pipelines/04_compositor_named_pad.pld",
+        ] {
+            let sample_path = repo_root().join(sample_name);
+            let raw = fs::read_to_string(sample_path).expect("sample fixture should exist");
+            let normalized = normalize_text(&raw);
+            let text = normalized.normalized_text;
+            let (graph, diagnostics) = parse_graph(&text);
+
+            for node in &graph.nodes {
+                let label = format!("node {}", node.id);
+                assert_span_inside_text(sample_name, &label, &text, &node.source_span);
+            }
+
+            for edge in &graph.edges {
+                let label = format!("edge {}", edge.id);
+                assert_span_inside_text(sample_name, &label, &text, &edge.source_span);
+            }
+
+            for diagnostic in diagnostics.iter().filter_map(|diagnostic| {
+                diagnostic
+                    .span
+                    .as_ref()
+                    .map(|span| (&diagnostic.code, span))
+            }) {
+                assert_span_inside_text(sample_name, diagnostic.0, &text, diagnostic.1);
+            }
         }
     }
 

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,18 +1,29 @@
-import { useState, type ChangeEvent } from 'react'
+import { useEffect, useState, type ChangeEvent } from 'react'
 import {
   isTauriRuntime,
   loadRemotePipeline,
   parsePipelineText,
+  probeLocalGStreamer,
   probeRemoteTarget,
   type RemoteTargetInput,
 } from './backend.ts'
+import {
+  firstVersionLine,
+  type GStreamerRuntimeStatus,
+} from './status.ts'
 import { HomeScreen } from '../features/home/HomeScreen.tsx'
+import {
+  ImportPreviewScreen,
+  type ImportPreviewViewModel,
+} from '../features/import-preview/ImportPreviewScreen.tsx'
 import { WorkspaceShell } from '../features/workspace/WorkspaceShell.tsx'
 import { toViewModel } from '../graph/fromBackend.ts'
 import type { PipelineDocumentViewModel } from '../graph/types.ts'
 
 function AppShell() {
   const [activeDocument, setActiveDocument] = useState<PipelineDocumentViewModel | null>(null)
+  const [pendingPreview, setPendingPreview] = useState<ImportPreviewViewModel | null>(null)
+  const [isGeneratingPreview, setIsGeneratingPreview] = useState(false)
   const [pipelineText, setPipelineText] = useState('')
   const [remoteTarget, setRemoteTarget] = useState<RemoteTargetInput>({
     host: '',
@@ -22,12 +33,72 @@ function AppShell() {
   })
   const [remotePath, setRemotePath] = useState('')
   const [activeRemoteTarget, setActiveRemoteTarget] = useState<RemoteTargetInput | null>(null)
+  const [previewRemoteTarget, setPreviewRemoteTarget] = useState<RemoteTargetInput | null>(null)
+  const [gstreamerStatus, setGstreamerStatus] = useState<GStreamerRuntimeStatus>(() => ({
+    local: {
+      message: isTauriRuntime()
+        ? '로컬 gst-inspect 확인 중...'
+        : '데스크톱 Tauri 런타임에서 확인할 수 있습니다.',
+      state: isTauriRuntime() ? 'checking' : 'unknown',
+    },
+    remote: {
+      message: '원격 미연결',
+      state: 'idle',
+    },
+  }))
   const [remoteStatusMessage, setRemoteStatusMessage] = useState(
     '원격 OE-Linux 장비가 준비되면 IP, 계정, 경로를 입력해 읽기 전용으로 불러올 수 있습니다.',
   )
   const [statusMessage, setStatusMessage] = useState(
     '로컬 파이프라인 파일을 열거나 텍스트를 붙여넣어 토폴로지로 변환하세요.',
   )
+
+  useEffect(() => {
+    if (!isTauriRuntime()) {
+      return
+    }
+
+    let isCancelled = false
+    probeLocalGStreamer()
+      .then((response) => {
+        if (isCancelled) {
+          return
+        }
+
+        const version = firstVersionLine(response.version_output)
+        setGstreamerStatus((current) => ({
+          ...current,
+          local: response.available
+            ? {
+                message: '로컬 GStreamer API 연결됨',
+                state: 'connected',
+                version: version ?? 'GStreamer version 확인됨',
+              }
+            : {
+                message: response.diagnostic ?? '로컬 gst-inspect-1.0을 찾지 못했습니다.',
+                state: 'failed',
+              },
+        }))
+      })
+      .catch((error) => {
+        if (isCancelled) {
+          return
+        }
+
+        console.error(error)
+        setGstreamerStatus((current) => ({
+          ...current,
+          local: {
+            message: '로컬 GStreamer API 확인에 실패했습니다.',
+            state: 'failed',
+          },
+        }))
+      })
+
+    return () => {
+      isCancelled = true
+    }
+  }, [])
 
   async function handlePipelineImport(rawText: string, sourceName: string) {
     if (!isTauriRuntime()) {
@@ -55,6 +126,43 @@ function AppShell() {
     }
   }
 
+  async function handlePipelinePreview(
+    rawText: string,
+    sourceName: string,
+    remoteContext: RemoteTargetInput | null = null,
+  ) {
+    if (!isTauriRuntime()) {
+      setStatusMessage('파일 미리보기는 데스크톱 Tauri 런타임이 필요합니다.')
+      return
+    }
+
+    setStatusMessage(`${sourceName} 미리보기 준비 중...`)
+
+    try {
+      const backendDocument = await parsePipelineText(rawText, sourceName)
+      const viewModel = await toViewModel(backendDocument)
+      setPendingPreview({
+        document: viewModel,
+        remoteHost: remoteContext?.host,
+        sourceName,
+        text: viewModel.normalizedText,
+      })
+      setPreviewRemoteTarget(remoteContext)
+      setActiveDocument(null)
+      setActiveRemoteTarget(null)
+      setStatusMessage(
+        viewModel.diagnostics.length
+          ? `${sourceName} 미리보기를 준비했습니다. 확인할 파서 진단 ${viewModel.diagnostics.length}건이 있습니다.`
+          : `${sourceName} 미리보기를 준비했습니다. 토폴로지 생성 전 원문을 확인하세요.`,
+      )
+    } catch (error) {
+      console.error(error)
+      setStatusMessage(
+        '미리보기를 준비하지 못했습니다. 파일 내용이나 파이프라인 구문을 확인한 뒤 다시 시도해 주세요.',
+      )
+    }
+  }
+
   async function handleFileSelected(event: ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0]
     if (!file) {
@@ -62,7 +170,7 @@ function AppShell() {
     }
 
     const rawText = await file.text()
-    await handlePipelineImport(rawText, file.name)
+    await handlePipelinePreview(rawText, file.name)
     event.target.value = ''
   }
 
@@ -73,6 +181,40 @@ function AppShell() {
     }
 
     await handlePipelineImport(pipelineText, '붙여넣은 파이프라인')
+  }
+
+  async function handleGeneratePreviewTopology() {
+    if (!pendingPreview) {
+      return
+    }
+
+    if (!pendingPreview.text.trim()) {
+      setStatusMessage('토폴로지를 생성하기 전에 파이프라인 텍스트를 확인해 주세요.')
+      return
+    }
+
+    setIsGeneratingPreview(true)
+    try {
+      const backendDocument = await parsePipelineText(
+        pendingPreview.text,
+        pendingPreview.sourceName,
+      )
+      const viewModel = await toViewModel(backendDocument)
+      setActiveDocument(viewModel)
+      setActiveRemoteTarget(previewRemoteTarget)
+      setPendingPreview(null)
+      setPreviewRemoteTarget(null)
+      setStatusMessage(
+        viewModel.diagnostics.length
+          ? `${pendingPreview.sourceName}에서 토폴로지를 생성했습니다. 확인할 파서 진단 ${viewModel.diagnostics.length}건이 있습니다.`
+          : `${pendingPreview.sourceName}에서 노드 ${viewModel.graph.nodes.length}개와 엣지 ${viewModel.graph.edges.length}개를 파싱했습니다.`,
+      )
+    } catch (error) {
+      console.error(error)
+      setStatusMessage('토폴로지를 생성하지 못했습니다. 미리보기 텍스트를 확인해 주세요.')
+    } finally {
+      setIsGeneratingPreview(false)
+    }
   }
 
   function sanitizeRemoteTarget(): RemoteTargetInput {
@@ -97,13 +239,42 @@ function AppShell() {
     }
 
     setRemoteStatusMessage(`${request.host} 접속 및 gst-inspect 확인 중...`)
+    setGstreamerStatus((current) => ({
+      ...current,
+      remote: {
+        host: request.host,
+        message: 'Remote Server 연결 확인 중...',
+        port: request.port,
+        state: 'checking',
+      },
+    }))
     try {
       const response = await probeRemoteTarget(request, 'videotestsrc')
+      const version = firstVersionLine(response.version_output)
+      setGstreamerStatus((current) => ({
+        ...current,
+        remote: {
+          host: response.host,
+          message: 'Remote Server 연결됨',
+          port: response.port,
+          state: 'connected',
+          version: version ?? 'GStreamer version 확인됨',
+        },
+      }))
       setRemoteStatusMessage(
         `${response.host} 접속 성공. ${response.version_output.split('\n')[0] ?? 'GStreamer 정보를 확인했습니다.'}`,
       )
     } catch (error) {
       console.error(error)
+      setGstreamerStatus((current) => ({
+        ...current,
+        remote: {
+          host: request.host,
+          message: 'Remote Server 연결 실패',
+          port: request.port,
+          state: 'failed',
+        },
+      }))
       setRemoteStatusMessage('원격 접속 또는 gst-inspect 확인에 실패했습니다. IP, 계정, PW, 네트워크를 확인해 주세요.')
     }
   }
@@ -121,25 +292,93 @@ function AppShell() {
     }
 
     setRemoteStatusMessage(`${request.host}:${remotePath.trim()} 원격 파일을 읽는 중...`)
+    setGstreamerStatus((current) => ({
+      ...current,
+      remote: {
+        ...current.remote,
+        host: request.host,
+        message: '원격 파일 읽는 중...',
+        port: request.port,
+        state: current.remote.state === 'connected' ? 'connected' : 'checking',
+      },
+    }))
     try {
       const backendDocument = await loadRemotePipeline(request, remotePath.trim())
       const viewModel = await toViewModel(backendDocument)
-      setActiveDocument(viewModel)
-      setActiveRemoteTarget(request)
+      setPendingPreview({
+        document: viewModel,
+        remoteHost: request.host,
+        sourceName: remotePath.trim(),
+        text: viewModel.normalizedText,
+      })
+      setPreviewRemoteTarget(request)
+      setActiveDocument(null)
+      setActiveRemoteTarget(null)
+      setGstreamerStatus((current) => ({
+        ...current,
+        remote: {
+          ...current.remote,
+          host: request.host,
+          message:
+            current.remote.state === 'connected'
+              ? '원격 파일 로드됨'
+              : '원격 파일 로드됨, GStreamer API 미확인',
+          port: request.port,
+          state: current.remote.state === 'connected' ? 'connected' : 'unknown',
+        },
+      }))
       setRemoteStatusMessage(
         viewModel.diagnostics.length
-          ? `원격 파이프라인을 열었습니다. 확인할 파서 진단 ${viewModel.diagnostics.length}건이 있습니다.`
-          : `원격 파이프라인을 열었습니다. 노드 ${viewModel.graph.nodes.length}개와 엣지 ${viewModel.graph.edges.length}개를 파싱했습니다.`,
+          ? `원격 파이프라인 미리보기를 열었습니다. 확인할 파서 진단 ${viewModel.diagnostics.length}건이 있습니다.`
+          : `원격 파이프라인 미리보기를 열었습니다. 노드 ${viewModel.graph.nodes.length}개와 엣지 ${viewModel.graph.edges.length}개를 파싱했습니다.`,
       )
     } catch (error) {
       console.error(error)
+      setGstreamerStatus((current) => ({
+        ...current,
+        remote: {
+          host: request.host,
+          message: '원격 파일 로드 실패',
+          port: request.port,
+          state: 'failed',
+        },
+      }))
       setRemoteStatusMessage('원격 파이프라인을 불러오지 못했습니다. 파일 경로와 권한을 확인해 주세요.')
     }
+  }
+
+  if (pendingPreview) {
+    return (
+      <ImportPreviewScreen
+        gstreamerStatus={gstreamerStatus}
+        isGenerating={isGeneratingPreview}
+        isTauri={isTauriRuntime()}
+        preview={pendingPreview}
+        statusMessage={statusMessage}
+        onBackHome={() => {
+          setPendingPreview(null)
+          setPreviewRemoteTarget(null)
+        }}
+        onConfirm={handleGeneratePreviewTopology}
+        onFileSelected={handleFileSelected}
+        onTextChange={(value) =>
+          setPendingPreview((current) =>
+            current
+              ? {
+                  ...current,
+                  text: value,
+                }
+              : current,
+          )
+        }
+      />
+    )
   }
 
   if (!activeDocument) {
     return (
       <HomeScreen
+        gstreamerStatus={gstreamerStatus}
         isTauri={isTauriRuntime()}
         pipelineText={pipelineText}
         statusMessage={statusMessage}
@@ -161,6 +400,7 @@ function AppShell() {
     <WorkspaceShell
       key={activeDocument.id}
       document={activeDocument}
+      gstreamerStatus={gstreamerStatus}
       remoteTarget={activeRemoteTarget}
       onBackHome={() => setActiveDocument(null)}
     />

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState, type ChangeEvent } from 'react'
 import {
   isTauriRuntime,
-  loadRemotePipeline,
   parsePipelineText,
   probeLocalGStreamer,
   probeRemoteTarget,
@@ -12,28 +11,25 @@ import {
   type GStreamerRuntimeStatus,
 } from './status.ts'
 import { HomeScreen } from '../features/home/HomeScreen.tsx'
-import {
-  ImportPreviewScreen,
-  type ImportPreviewViewModel,
-} from '../features/import-preview/ImportPreviewScreen.tsx'
 import { WorkspaceShell } from '../features/workspace/WorkspaceShell.tsx'
 import { toViewModel } from '../graph/fromBackend.ts'
 import type { PipelineDocumentViewModel } from '../graph/types.ts'
 
+type ConnectionMode = 'local' | 'remote'
+
 function AppShell() {
   const [activeDocument, setActiveDocument] = useState<PipelineDocumentViewModel | null>(null)
-  const [pendingPreview, setPendingPreview] = useState<ImportPreviewViewModel | null>(null)
-  const [isGeneratingPreview, setIsGeneratingPreview] = useState(false)
+  const [connectionMode, setConnectionMode] = useState<ConnectionMode>('local')
   const [pipelineText, setPipelineText] = useState('')
+  const [pipelineSourceName, setPipelineSourceName] = useState('붙여넣은 파이프라인')
   const [remoteTarget, setRemoteTarget] = useState<RemoteTargetInput>({
     host: '',
     port: 22,
     username: '',
     password: '',
   })
-  const [remotePath, setRemotePath] = useState('')
   const [activeRemoteTarget, setActiveRemoteTarget] = useState<RemoteTargetInput | null>(null)
-  const [previewRemoteTarget, setPreviewRemoteTarget] = useState<RemoteTargetInput | null>(null)
+  const [verifiedRemoteTarget, setVerifiedRemoteTarget] = useState<RemoteTargetInput | null>(null)
   const [gstreamerStatus, setGstreamerStatus] = useState<GStreamerRuntimeStatus>(() => ({
     local: {
       message: isTauriRuntime()
@@ -46,12 +42,8 @@ function AppShell() {
       state: 'idle',
     },
   }))
-  const [remoteStatusMessage, setRemoteStatusMessage] = useState(
-    '원격 OE-Linux 장비가 준비되면 IP, 계정, 경로를 입력해 읽기 전용으로 불러올 수 있습니다.',
-  )
-  const [statusMessage, setStatusMessage] = useState(
-    '로컬 파이프라인 파일을 열거나 텍스트를 붙여넣어 토폴로지로 변환하세요.',
-  )
+  const [remoteStatusMessage, setRemoteStatusMessage] = useState('')
+  const [statusMessage, setStatusMessage] = useState('')
 
   useEffect(() => {
     if (!isTauriRuntime()) {
@@ -112,7 +104,11 @@ function AppShell() {
       const backendDocument = await parsePipelineText(rawText, sourceName)
       const viewModel = await toViewModel(backendDocument)
       setActiveDocument(viewModel)
-      setActiveRemoteTarget(null)
+      setActiveRemoteTarget(
+        connectionMode === 'remote' && verifiedRemoteTarget
+          ? verifiedRemoteTarget
+          : null,
+      )
       setStatusMessage(
         viewModel.diagnostics.length
           ? `${sourceName}에서 토폴로지를 생성했습니다. 확인할 파서 진단 ${viewModel.diagnostics.length}건이 있습니다.`
@@ -126,43 +122,6 @@ function AppShell() {
     }
   }
 
-  async function handlePipelinePreview(
-    rawText: string,
-    sourceName: string,
-    remoteContext: RemoteTargetInput | null = null,
-  ) {
-    if (!isTauriRuntime()) {
-      setStatusMessage('파일 미리보기는 데스크톱 Tauri 런타임이 필요합니다.')
-      return
-    }
-
-    setStatusMessage(`${sourceName} 미리보기 준비 중...`)
-
-    try {
-      const backendDocument = await parsePipelineText(rawText, sourceName)
-      const viewModel = await toViewModel(backendDocument)
-      setPendingPreview({
-        document: viewModel,
-        remoteHost: remoteContext?.host,
-        sourceName,
-        text: viewModel.normalizedText,
-      })
-      setPreviewRemoteTarget(remoteContext)
-      setActiveDocument(null)
-      setActiveRemoteTarget(null)
-      setStatusMessage(
-        viewModel.diagnostics.length
-          ? `${sourceName} 미리보기를 준비했습니다. 확인할 파서 진단 ${viewModel.diagnostics.length}건이 있습니다.`
-          : `${sourceName} 미리보기를 준비했습니다. 토폴로지 생성 전 원문을 확인하세요.`,
-      )
-    } catch (error) {
-      console.error(error)
-      setStatusMessage(
-        '미리보기를 준비하지 못했습니다. 파일 내용이나 파이프라인 구문을 확인한 뒤 다시 시도해 주세요.',
-      )
-    }
-  }
-
   async function handleFileSelected(event: ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0]
     if (!file) {
@@ -170,7 +129,33 @@ function AppShell() {
     }
 
     const rawText = await file.text()
-    await handlePipelinePreview(rawText, file.name)
+    setPipelineSourceName(file.name)
+
+    if (!isTauriRuntime()) {
+      setPipelineText(rawText)
+      setStatusMessage(`${file.name} 내용을 입력 영역에 불러왔습니다.`)
+      event.target.value = ''
+      return
+    }
+
+    setStatusMessage(`${file.name} 내용을 정규화하는 중...`)
+
+    try {
+      const backendDocument = await parsePipelineText(rawText, file.name)
+      setPipelineText(backendDocument.normalized_text)
+      setStatusMessage(
+        backendDocument.diagnostics.length
+          ? `${file.name} 내용을 입력 영역에 불러왔습니다. 확인할 파서 진단 ${backendDocument.diagnostics.length}건이 있습니다.`
+          : `${file.name} 내용을 입력 영역에 불러왔습니다. 필요하면 수정한 뒤 토폴로지를 생성하세요.`,
+      )
+    } catch (error) {
+      console.error(error)
+      setPipelineText(rawText)
+      setStatusMessage(
+        `${file.name} 정규화에 실패해 원문을 입력 영역에 불러왔습니다. 내용을 확인해 주세요.`,
+      )
+    }
+
     event.target.value = ''
   }
 
@@ -180,41 +165,7 @@ function AppShell() {
       return
     }
 
-    await handlePipelineImport(pipelineText, '붙여넣은 파이프라인')
-  }
-
-  async function handleGeneratePreviewTopology() {
-    if (!pendingPreview) {
-      return
-    }
-
-    if (!pendingPreview.text.trim()) {
-      setStatusMessage('토폴로지를 생성하기 전에 파이프라인 텍스트를 확인해 주세요.')
-      return
-    }
-
-    setIsGeneratingPreview(true)
-    try {
-      const backendDocument = await parsePipelineText(
-        pendingPreview.text,
-        pendingPreview.sourceName,
-      )
-      const viewModel = await toViewModel(backendDocument)
-      setActiveDocument(viewModel)
-      setActiveRemoteTarget(previewRemoteTarget)
-      setPendingPreview(null)
-      setPreviewRemoteTarget(null)
-      setStatusMessage(
-        viewModel.diagnostics.length
-          ? `${pendingPreview.sourceName}에서 토폴로지를 생성했습니다. 확인할 파서 진단 ${viewModel.diagnostics.length}건이 있습니다.`
-          : `${pendingPreview.sourceName}에서 노드 ${viewModel.graph.nodes.length}개와 엣지 ${viewModel.graph.edges.length}개를 파싱했습니다.`,
-      )
-    } catch (error) {
-      console.error(error)
-      setStatusMessage('토폴로지를 생성하지 못했습니다. 미리보기 텍스트를 확인해 주세요.')
-    } finally {
-      setIsGeneratingPreview(false)
-    }
+    await handlePipelineImport(pipelineText, pipelineSourceName)
   }
 
   function sanitizeRemoteTarget(): RemoteTargetInput {
@@ -224,6 +175,26 @@ function AppShell() {
       username: remoteTarget.username.trim(),
       port: Number(remoteTarget.port || 22),
     }
+  }
+
+  function handlePipelineTextChange(value: string) {
+    setPipelineText(value)
+    setPipelineSourceName('붙여넣은 파이프라인')
+  }
+
+  function handleRemoteTargetChange(value: RemoteTargetInput) {
+    setRemoteTarget(value)
+    setVerifiedRemoteTarget(null)
+    setGstreamerStatus((current) => ({
+      ...current,
+      remote: {
+        host: value.host.trim() || undefined,
+        message: '원격 미연결',
+        port: Number(value.port || 22),
+        state: 'idle',
+      },
+    }))
+    setRemoteStatusMessage('')
   }
 
   async function handleProbeRemote() {
@@ -261,6 +232,11 @@ function AppShell() {
           version: version ?? 'GStreamer version 확인됨',
         },
       }))
+      setVerifiedRemoteTarget({
+        ...request,
+        host: response.host,
+        port: response.port,
+      })
       setRemoteStatusMessage(
         `${response.host} 접속 성공. ${response.version_output.split('\n')[0] ?? 'GStreamer 정보를 확인했습니다.'}`,
       )
@@ -275,123 +251,26 @@ function AppShell() {
           state: 'failed',
         },
       }))
+      setVerifiedRemoteTarget(null)
       setRemoteStatusMessage('원격 접속 또는 gst-inspect 확인에 실패했습니다. IP, 계정, PW, 네트워크를 확인해 주세요.')
     }
-  }
-
-  async function handleLoadRemotePipeline() {
-    if (!isTauriRuntime()) {
-      setRemoteStatusMessage('원격 파이프라인 불러오기는 데스크톱 Tauri 런타임에서만 사용할 수 있습니다.')
-      return
-    }
-
-    const request = sanitizeRemoteTarget()
-    if (!request.host || !request.username || !request.password || !remotePath.trim()) {
-      setRemoteStatusMessage('원격 IP, 계정 ID, PW, 파이프라인 파일 경로를 모두 입력해 주세요.')
-      return
-    }
-
-    setRemoteStatusMessage(`${request.host}:${remotePath.trim()} 원격 파일을 읽는 중...`)
-    setGstreamerStatus((current) => ({
-      ...current,
-      remote: {
-        ...current.remote,
-        host: request.host,
-        message: '원격 파일 읽는 중...',
-        port: request.port,
-        state: current.remote.state === 'connected' ? 'connected' : 'checking',
-      },
-    }))
-    try {
-      const backendDocument = await loadRemotePipeline(request, remotePath.trim())
-      const viewModel = await toViewModel(backendDocument)
-      setPendingPreview({
-        document: viewModel,
-        remoteHost: request.host,
-        sourceName: remotePath.trim(),
-        text: viewModel.normalizedText,
-      })
-      setPreviewRemoteTarget(request)
-      setActiveDocument(null)
-      setActiveRemoteTarget(null)
-      setGstreamerStatus((current) => ({
-        ...current,
-        remote: {
-          ...current.remote,
-          host: request.host,
-          message:
-            current.remote.state === 'connected'
-              ? '원격 파일 로드됨'
-              : '원격 파일 로드됨, GStreamer API 미확인',
-          port: request.port,
-          state: current.remote.state === 'connected' ? 'connected' : 'unknown',
-        },
-      }))
-      setRemoteStatusMessage(
-        viewModel.diagnostics.length
-          ? `원격 파이프라인 미리보기를 열었습니다. 확인할 파서 진단 ${viewModel.diagnostics.length}건이 있습니다.`
-          : `원격 파이프라인 미리보기를 열었습니다. 노드 ${viewModel.graph.nodes.length}개와 엣지 ${viewModel.graph.edges.length}개를 파싱했습니다.`,
-      )
-    } catch (error) {
-      console.error(error)
-      setGstreamerStatus((current) => ({
-        ...current,
-        remote: {
-          host: request.host,
-          message: '원격 파일 로드 실패',
-          port: request.port,
-          state: 'failed',
-        },
-      }))
-      setRemoteStatusMessage('원격 파이프라인을 불러오지 못했습니다. 파일 경로와 권한을 확인해 주세요.')
-    }
-  }
-
-  if (pendingPreview) {
-    return (
-      <ImportPreviewScreen
-        gstreamerStatus={gstreamerStatus}
-        isGenerating={isGeneratingPreview}
-        isTauri={isTauriRuntime()}
-        preview={pendingPreview}
-        statusMessage={statusMessage}
-        onBackHome={() => {
-          setPendingPreview(null)
-          setPreviewRemoteTarget(null)
-        }}
-        onConfirm={handleGeneratePreviewTopology}
-        onFileSelected={handleFileSelected}
-        onTextChange={(value) =>
-          setPendingPreview((current) =>
-            current
-              ? {
-                  ...current,
-                  text: value,
-                }
-              : current,
-          )
-        }
-      />
-    )
   }
 
   if (!activeDocument) {
     return (
       <HomeScreen
+        connectionMode={connectionMode}
         gstreamerStatus={gstreamerStatus}
-        isTauri={isTauriRuntime()}
         pipelineText={pipelineText}
         statusMessage={statusMessage}
-        remotePath={remotePath}
         remoteStatusMessage={remoteStatusMessage}
         remoteTarget={remoteTarget}
+        onConnectionModeChange={setConnectionMode}
         onFileSelected={handleFileSelected}
-        onLoadRemotePipeline={handleLoadRemotePipeline}
         onParseText={handleParsePastedText}
-        onPipelineTextChange={setPipelineText}
+        onPipelineTextChange={handlePipelineTextChange}
         onProbeRemote={handleProbeRemote}
-        onRemotePathChange={setRemotePath}
-        onRemoteTargetChange={setRemoteTarget}
+        onRemoteTargetChange={handleRemoteTargetChange}
       />
     )
   }

--- a/src/app/status.ts
+++ b/src/app/status.ts
@@ -1,0 +1,18 @@
+export type RuntimeStatusState = 'checking' | 'connected' | 'failed' | 'idle' | 'unknown'
+
+export type RuntimeEndpointStatus = {
+  host?: string
+  message?: string
+  port?: number
+  state: RuntimeStatusState
+  version?: string
+}
+
+export type GStreamerRuntimeStatus = {
+  local: RuntimeEndpointStatus
+  remote: RuntimeEndpointStatus
+}
+
+export function firstVersionLine(versionOutput?: string | null) {
+  return versionOutput?.split('\n').find((line) => line.trim())?.trim()
+}

--- a/src/components/ConnectionBadge.tsx
+++ b/src/components/ConnectionBadge.tsx
@@ -1,0 +1,43 @@
+import type { RuntimeEndpointStatus } from '../app/status.ts'
+
+type ConnectionBadgeProps = {
+  label: string
+  status: RuntimeEndpointStatus
+}
+
+function statusText(status: RuntimeEndpointStatus) {
+  switch (status.state) {
+    case 'checking':
+      return '확인 중'
+    case 'connected':
+      return '연결됨'
+    case 'failed':
+      return '연결 실패'
+    case 'idle':
+      return '미연결'
+    case 'unknown':
+      return '알 수 없음'
+  }
+}
+
+function ConnectionBadge({ label, status }: ConnectionBadgeProps) {
+  const endpoint = status.host
+    ? `${status.host}${status.port ? `:${status.port}` : ''}`
+    : undefined
+  const details = endpoint ?? status.version ?? status.message ?? statusText(status)
+
+  return (
+    <span
+      className={`connection-badge connection-badge--${status.state}`}
+      title={[label, endpoint, status.version, status.message].filter(Boolean).join(' · ')}
+    >
+      <span className="status-dot" aria-hidden />
+      <span className="connection-badge__copy">
+        <strong>{label}</strong>
+        <em>{details}</em>
+      </span>
+    </span>
+  )
+}
+
+export { ConnectionBadge }

--- a/src/components/ConnectionBadge.tsx
+++ b/src/components/ConnectionBadge.tsx
@@ -24,7 +24,7 @@ function ConnectionBadge({ label, status }: ConnectionBadgeProps) {
   const endpoint = status.host
     ? `${status.host}${status.port ? `:${status.port}` : ''}`
     : undefined
-  const details = endpoint ?? status.version ?? status.message ?? statusText(status)
+  const details = status.version ?? endpoint ?? status.message ?? statusText(status)
 
   return (
     <span

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -5,6 +5,7 @@ type IconName =
   | 'fileText'
   | 'folderOpen'
   | 'info'
+  | 'monitor'
   | 'panelRight'
   | 'server'
 
@@ -70,6 +71,14 @@ function Icon({ name }: IconProps) {
           <circle cx="12" cy="12" r="9" />
           <path d="M12 11v5" />
           <path d="M12 8h.01" />
+        </svg>
+      )
+    case 'monitor':
+      return (
+        <svg {...commonProps}>
+          <rect height="12" rx="2" width="18" x="3" y="4" />
+          <path d="M8 20h8" />
+          <path d="M12 16v4" />
         </svg>
       )
     case 'panelRight':

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -1,0 +1,97 @@
+type IconName =
+  | 'arrowLeft'
+  | 'close'
+  | 'diagnostics'
+  | 'fileText'
+  | 'folderOpen'
+  | 'info'
+  | 'panelRight'
+  | 'server'
+
+type IconProps = {
+  name: IconName
+}
+
+function Icon({ name }: IconProps) {
+  const commonProps = {
+    'aria-hidden': true,
+    className: 'ui-icon',
+    fill: 'none',
+    focusable: false,
+    stroke: 'currentColor',
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+    strokeWidth: 2,
+    viewBox: '0 0 24 24',
+  }
+
+  switch (name) {
+    case 'arrowLeft':
+      return (
+        <svg {...commonProps}>
+          <path d="M19 12H5" />
+          <path d="m12 19-7-7 7-7" />
+        </svg>
+      )
+    case 'close':
+      return (
+        <svg {...commonProps}>
+          <path d="M18 6 6 18" />
+          <path d="m6 6 12 12" />
+        </svg>
+      )
+    case 'diagnostics':
+      return (
+        <svg {...commonProps}>
+          <path d="m12 3 9 16H3L12 3Z" />
+          <path d="M12 9v4" />
+          <path d="M12 17h.01" />
+        </svg>
+      )
+    case 'fileText':
+      return (
+        <svg {...commonProps}>
+          <path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9Z" />
+          <path d="M14 3v6h6" />
+          <path d="M8 13h8" />
+          <path d="M8 17h5" />
+        </svg>
+      )
+    case 'folderOpen':
+      return (
+        <svg {...commonProps}>
+          <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v2" />
+          <path d="M3 11h18l-2 8a2 2 0 0 1-2 1H5a2 2 0 0 1-2-1Z" />
+        </svg>
+      )
+    case 'info':
+      return (
+        <svg {...commonProps}>
+          <circle cx="12" cy="12" r="9" />
+          <path d="M12 11v5" />
+          <path d="M12 8h.01" />
+        </svg>
+      )
+    case 'panelRight':
+      return (
+        <svg {...commonProps}>
+          <rect height="16" rx="2" width="18" x="3" y="4" />
+          <path d="M15 4v16" />
+          <path d="M7 8h4" />
+          <path d="M7 12h4" />
+        </svg>
+      )
+    case 'server':
+      return (
+        <svg {...commonProps}>
+          <rect height="7" rx="2" width="18" x="3" y="4" />
+          <rect height="7" rx="2" width="18" x="3" y="13" />
+          <path d="M7 8h.01" />
+          <path d="M7 17h.01" />
+        </svg>
+      )
+  }
+}
+
+export { Icon }
+export type { IconName }

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,0 +1,45 @@
+import { Icon, type IconName } from './Icon.tsx'
+
+type IconButtonProps = {
+  active?: boolean
+  badge?: number | string
+  className?: string
+  disabled?: boolean
+  icon: IconName
+  label: string
+  onClick?: () => void
+  type?: 'button' | 'submit'
+}
+
+function IconButton({
+  active = false,
+  badge,
+  className,
+  disabled,
+  icon,
+  label,
+  onClick,
+  type = 'button',
+}: IconButtonProps) {
+  const classes = [
+    'icon-button',
+    active ? 'is-active' : '',
+    className ?? '',
+  ].filter(Boolean).join(' ')
+
+  return (
+    <button
+      aria-label={label}
+      className={classes}
+      disabled={disabled}
+      onClick={onClick}
+      title={label}
+      type={type}
+    >
+      <Icon name={icon} />
+      {badge ? <span className="icon-button__badge">{badge}</span> : null}
+    </button>
+  )
+}
+
+export { IconButton }

--- a/src/features/home/HomeScreen.tsx
+++ b/src/features/home/HomeScreen.tsx
@@ -1,7 +1,12 @@
-import type { ChangeEvent } from 'react'
+import { useState, type ChangeEvent } from 'react'
 import type { RemoteTargetInput } from '../../app/backend.ts'
+import type { GStreamerRuntimeStatus } from '../../app/status.ts'
+import { ConnectionBadge } from '../../components/ConnectionBadge.tsx'
+import { Icon } from '../../components/Icon.tsx'
+import { IconButton } from '../../components/IconButton.tsx'
 
 type HomeScreenProps = {
+  gstreamerStatus: GStreamerRuntimeStatus
   isTauri: boolean
   pipelineText: string
   remotePath: string
@@ -18,6 +23,7 @@ type HomeScreenProps = {
 }
 
 function HomeScreen({
+  gstreamerStatus,
   isTauri,
   onFileSelected,
   onLoadRemotePipeline,
@@ -32,6 +38,7 @@ function HomeScreen({
   onRemotePathChange,
   onRemoteTargetChange,
 }: HomeScreenProps) {
+  const [isRemoteModalOpen, setIsRemoteModalOpen] = useState(false)
   const canUseRemote =
     remoteTarget.host.trim() &&
     remoteTarget.username.trim() &&
@@ -43,6 +50,8 @@ function HomeScreen({
         <section className="launcher-card panel">
           <div className="launcher-card__header">
             <div className="launcher-card__badges">
+              <ConnectionBadge label="GStreamer API" status={gstreamerStatus.local} />
+              <ConnectionBadge label="Remote Server" status={gstreamerStatus.remote} />
               <span className="card-chip muted-chip">
                 {isTauri ? '데스크톱 백엔드 준비됨' : '브라우저 미리보기 전용'}
               </span>
@@ -61,8 +70,14 @@ function HomeScreen({
 
           <div className="launcher-card__body">
             <div className="launcher-card__actions">
-              <label className="primary-button upload-action" htmlFor="local-pipeline-file">
-                로컬 파이프라인 열기
+              <label
+                aria-label="로컬 파이프라인 파일 열기"
+                className="icon-button icon-upload-button icon-button--primary"
+                htmlFor="local-pipeline-file"
+                title="로컬 파이프라인 파일 열기"
+              >
+                <Icon name="folderOpen" />
+                <span className="sr-only">로컬 파이프라인 파일 열기</span>
                 <input
                   id="local-pipeline-file"
                   onChange={onFileSelected}
@@ -110,13 +125,53 @@ function HomeScreen({
             </div>
 
             <div className="launcher-divider" role="presentation">
-              <span>또는 Remote Server에서 불러오기</span>
+              <span>Remote Server 연결</span>
             </div>
+
+            <section className="remote-entry">
+              <button
+                className="remote-entry__button"
+                onClick={() => setIsRemoteModalOpen(true)}
+                type="button"
+              >
+                <span className="remote-entry__icon">
+                  <Icon name="server" />
+                </span>
+                <span>
+                  <strong>Remote Server</strong>
+                  <em>대상 장비의 GStreamer metadata를 읽기 전용으로 확인합니다.</em>
+                </span>
+              </button>
+              <ConnectionBadge label="Remote Server" status={gstreamerStatus.remote} />
+              <span className="status-message">{remoteStatusMessage}</span>
+            </section>
+          </div>
+        </section>
+      </section>
+
+      {isRemoteModalOpen ? (
+        <div className="remote-modal" role="dialog" aria-modal="true" aria-labelledby="remote-modal-title">
+          <section className="remote-modal__card panel">
+            <header className="remote-modal__header">
+              <div>
+                <div className="eyebrow">Remote Server</div>
+                <h2 id="remote-modal-title">Remote Server 연결</h2>
+                <p className="muted-copy">
+                  OE-Linux 대상 장비에서 GStreamer API와 Pipeline 파일을 읽기 전용으로
+                  확인합니다.
+                </p>
+              </div>
+              <IconButton
+                icon="close"
+                label="Remote Server 창 닫기"
+                onClick={() => setIsRemoteModalOpen(false)}
+              />
+            </header>
 
             <section className="remote-card">
               <div className="remote-card__grid">
                 <label>
-                  <span className="field-label">IP</span>
+                  <span className="field-label">IP / Host</span>
                   <input
                     className="text-field"
                     onChange={(event) =>
@@ -175,7 +230,7 @@ function HomeScreen({
               </div>
 
               <label className="remote-card__path">
-                <span className="field-label">Remote Server Pipeline 파일 경로</span>
+                <span className="field-label">Remote Pipeline 파일 경로</span>
                 <input
                   className="text-field"
                   onChange={(event) => onRemotePathChange(event.target.value)}
@@ -200,19 +255,20 @@ function HomeScreen({
                     onClick={onLoadRemotePipeline}
                     type="button"
                   >
-                    원격 토폴로지 생성
+                    원격 파일 미리보기
                   </button>
                 </div>
 
                 <div className="status-strip">
                   <span className="card-chip muted-chip">읽기 전용 SSH/SFTP</span>
+                  <ConnectionBadge label="Remote Server" status={gstreamerStatus.remote} />
                   <span className="status-message">{remoteStatusMessage}</span>
                 </div>
               </div>
             </section>
-          </div>
-        </section>
-      </section>
+          </section>
+        </div>
+      ) : null}
     </main>
   )
 }

--- a/src/features/home/HomeScreen.tsx
+++ b/src/features/home/HomeScreen.tsx
@@ -5,37 +5,35 @@ import { ConnectionBadge } from '../../components/ConnectionBadge.tsx'
 import { Icon } from '../../components/Icon.tsx'
 import { IconButton } from '../../components/IconButton.tsx'
 
+type ConnectionMode = 'local' | 'remote'
+
 type HomeScreenProps = {
+  connectionMode: ConnectionMode
   gstreamerStatus: GStreamerRuntimeStatus
-  isTauri: boolean
   pipelineText: string
-  remotePath: string
   remoteStatusMessage: string
   remoteTarget: RemoteTargetInput
   statusMessage: string
+  onConnectionModeChange: (value: ConnectionMode) => void
   onFileSelected: (event: ChangeEvent<HTMLInputElement>) => void
-  onLoadRemotePipeline: () => void
   onParseText: () => void
   onPipelineTextChange: (value: string) => void
   onProbeRemote: () => void
-  onRemotePathChange: (value: string) => void
   onRemoteTargetChange: (value: RemoteTargetInput) => void
 }
 
 function HomeScreen({
+  connectionMode,
   gstreamerStatus,
-  isTauri,
+  onConnectionModeChange,
   onFileSelected,
-  onLoadRemotePipeline,
   pipelineText,
-  remotePath,
   remoteStatusMessage,
   remoteTarget,
   statusMessage,
   onParseText,
   onPipelineTextChange,
   onProbeRemote,
-  onRemotePathChange,
   onRemoteTargetChange,
 }: HomeScreenProps) {
   const [isRemoteModalOpen, setIsRemoteModalOpen] = useState(false)
@@ -43,124 +41,90 @@ function HomeScreen({
     remoteTarget.host.trim() &&
     remoteTarget.username.trim() &&
     remoteTarget.password.trim()
+  const apiStatus =
+    connectionMode === 'remote' ? gstreamerStatus.remote : gstreamerStatus.local
+
+  function selectLocalMode() {
+    onConnectionModeChange('local')
+    setIsRemoteModalOpen(false)
+  }
+
+  function openRemoteModal() {
+    onConnectionModeChange('remote')
+    setIsRemoteModalOpen(true)
+  }
 
   return (
     <main className="app-shell app-shell--home">
       <section className="home-screen home-screen--focused">
-        <section className="launcher-card panel">
-          <div className="launcher-card__header">
-            <div className="launcher-card__badges">
-              <ConnectionBadge label="GStreamer API" status={gstreamerStatus.local} />
-              <ConnectionBadge label="Remote Server" status={gstreamerStatus.remote} />
-              <span className="card-chip muted-chip">
-                {isTauri ? '데스크톱 백엔드 준비됨' : '브라우저 미리보기 전용'}
-              </span>
-            </div>
+        <section className="launcher-card launcher-card--single panel">
+          <header className="launcher-card__topbar">
+            <h1>GStreamer Topology</h1>
 
-            <div className="launcher-card__copy">
-              <div className="eyebrow">로컬 파일 / Remote Server</div>
-              <h1>GStreamer Topology</h1>
-              <p className="hero-body">
-                로컬 `.pld`, `.txt`, `.rtf` 파일을 가져오거나 파이프라인 텍스트를
-                붙여넣고, Remote Server의 OE-Linux 파이프라인도 같은 캔버스에서
-                확인하세요. 예제 파일은 <code>fixtures/pipelines/</code> 폴더에 있습니다.
-              </p>
-            </div>
-          </div>
+            <div className="home-toolbar" aria-label="시작 화면 작업">
+              <ConnectionBadge label="GStreamer API" status={apiStatus} />
 
-          <div className="launcher-card__body">
-            <div className="launcher-card__actions">
               <label
                 aria-label="로컬 파이프라인 파일 열기"
-                className="icon-button icon-upload-button icon-button--primary"
+                className="icon-button icon-upload-button"
                 htmlFor="local-pipeline-file"
                 title="로컬 파이프라인 파일 열기"
               >
                 <Icon name="folderOpen" />
                 <span className="sr-only">로컬 파이프라인 파일 열기</span>
                 <input
+                  accept=".txt,.pld,.rtf,.pld.rtf"
                   id="local-pipeline-file"
                   onChange={onFileSelected}
                   type="file"
-                  accept=".txt,.pld,.rtf,.pld.rtf"
                 />
               </label>
 
-              <div className="launcher-card__formats">
-                <span className="card-chip muted-chip">.pld</span>
-                <span className="card-chip muted-chip">.txt</span>
-                <span className="card-chip muted-chip">.rtf</span>
-              </div>
-            </div>
-
-            <div className="launcher-divider" role="presentation">
-              <span>또는 파이프라인 텍스트 붙여넣기</span>
-            </div>
-
-            <div className="launcher-card__paste">
-              <textarea
-                className="text-area"
-                onChange={(event) => onPipelineTextChange(event.target.value)}
-                placeholder="videotestsrc pattern=smpte ! videoconvert ! autovideosink"
-                value={pipelineText}
+              <IconButton
+                active={connectionMode === 'local'}
+                icon="monitor"
+                label="Local 모드"
+                onClick={selectLocalMode}
               />
-
-              <div className="launcher-card__footer">
-                <button
-                  className="secondary-button"
-                  disabled={!pipelineText.trim()}
-                  onClick={onParseText}
-                  type="button"
-                >
-                  토폴로지 생성
-                </button>
-
-                <div className="status-strip">
-                  <span className="card-chip muted-chip">
-                    {isTauri ? '로컬 파싱 경로' : '데스크톱 런타임 필요'}
-                  </span>
-                  <span className="status-message">{statusMessage}</span>
-                </div>
-              </div>
+              <IconButton
+                active={connectionMode === 'remote'}
+                badge={gstreamerStatus.remote.state === 'connected' ? '•' : undefined}
+                icon="server"
+                label="Remote Server 연결"
+                onClick={openRemoteModal}
+              />
             </div>
+          </header>
 
-            <div className="launcher-divider" role="presentation">
-              <span>Remote Server 연결</span>
-            </div>
+          <section className="launcher-card__main">
+            <textarea
+              className="text-area pipeline-input"
+              onChange={(event) => onPipelineTextChange(event.target.value)}
+              placeholder="videotestsrc pattern=smpte ! videoconvert ! autovideosink"
+              value={pipelineText}
+            />
 
-            <section className="remote-entry">
-              <button
-                className="remote-entry__button"
-                onClick={() => setIsRemoteModalOpen(true)}
-                type="button"
-              >
-                <span className="remote-entry__icon">
-                  <Icon name="server" />
-                </span>
-                <span>
-                  <strong>Remote Server</strong>
-                  <em>대상 장비의 GStreamer metadata를 읽기 전용으로 확인합니다.</em>
-                </span>
-              </button>
-              <ConnectionBadge label="Remote Server" status={gstreamerStatus.remote} />
-              <span className="status-message">{remoteStatusMessage}</span>
-            </section>
-          </div>
+            <button
+              className="primary-button topology-generate-button"
+              disabled={!pipelineText.trim()}
+              onClick={onParseText}
+              type="button"
+            >
+              토폴로지 생성
+            </button>
+
+            {statusMessage ? (
+              <p className="home-status-line">{statusMessage}</p>
+            ) : null}
+          </section>
         </section>
       </section>
 
       {isRemoteModalOpen ? (
         <div className="remote-modal" role="dialog" aria-modal="true" aria-labelledby="remote-modal-title">
-          <section className="remote-modal__card panel">
+          <section className="remote-modal__card remote-modal__card--compact panel">
             <header className="remote-modal__header">
-              <div>
-                <div className="eyebrow">Remote Server</div>
-                <h2 id="remote-modal-title">Remote Server 연결</h2>
-                <p className="muted-copy">
-                  OE-Linux 대상 장비에서 GStreamer API와 Pipeline 파일을 읽기 전용으로
-                  확인합니다.
-                </p>
-              </div>
+              <h2 id="remote-modal-title">Remote Server 연결</h2>
               <IconButton
                 icon="close"
                 label="Remote Server 창 닫기"
@@ -168,7 +132,7 @@ function HomeScreen({
               />
             </header>
 
-            <section className="remote-card">
+            <section className="remote-card remote-card--compact">
               <div className="remote-card__grid">
                 <label>
                   <span className="field-label">IP / Host</span>
@@ -229,42 +193,21 @@ function HomeScreen({
                 </label>
               </div>
 
-              <label className="remote-card__path">
-                <span className="field-label">Remote Pipeline 파일 경로</span>
-                <input
-                  className="text-field"
-                  onChange={(event) => onRemotePathChange(event.target.value)}
-                  placeholder="/home/root/pipeline.pld"
-                  value={remotePath}
-                />
-              </label>
-
-              <div className="launcher-card__footer">
-                <div className="remote-card__actions">
-                  <button
-                    className="secondary-button"
-                    disabled={!canUseRemote}
-                    onClick={onProbeRemote}
-                    type="button"
-                  >
-                    원격 접속 확인
-                  </button>
-                  <button
-                    className="secondary-button"
-                    disabled={!canUseRemote || !remotePath.trim()}
-                    onClick={onLoadRemotePipeline}
-                    type="button"
-                  >
-                    원격 파일 미리보기
-                  </button>
-                </div>
-
-                <div className="status-strip">
-                  <span className="card-chip muted-chip">읽기 전용 SSH/SFTP</span>
-                  <ConnectionBadge label="Remote Server" status={gstreamerStatus.remote} />
-                  <span className="status-message">{remoteStatusMessage}</span>
-                </div>
+              <div className="remote-card__footer">
+                <button
+                  className="primary-button remote-connect-button"
+                  disabled={!canUseRemote}
+                  onClick={onProbeRemote}
+                  type="button"
+                >
+                  접속
+                </button>
+                <ConnectionBadge label="Remote Server" status={gstreamerStatus.remote} />
               </div>
+
+              {remoteStatusMessage ? (
+                <p className="remote-status-line">{remoteStatusMessage}</p>
+              ) : null}
             </section>
           </section>
         </div>

--- a/src/features/import-preview/ImportPreviewScreen.tsx
+++ b/src/features/import-preview/ImportPreviewScreen.tsx
@@ -1,0 +1,129 @@
+import type { ChangeEvent } from 'react'
+import { Icon } from '../../components/Icon.tsx'
+import { IconButton } from '../../components/IconButton.tsx'
+import { ConnectionBadge } from '../../components/ConnectionBadge.tsx'
+import type { GStreamerRuntimeStatus } from '../../app/status.ts'
+import type { PipelineDocumentViewModel } from '../../graph/types.ts'
+
+export type ImportPreviewViewModel = {
+  document: PipelineDocumentViewModel
+  remoteHost?: string
+  sourceName: string
+  text: string
+}
+
+type ImportPreviewScreenProps = {
+  gstreamerStatus: GStreamerRuntimeStatus
+  isGenerating: boolean
+  isTauri: boolean
+  onBackHome: () => void
+  onConfirm: () => void
+  onFileSelected: (event: ChangeEvent<HTMLInputElement>) => void
+  onTextChange: (value: string) => void
+  preview: ImportPreviewViewModel
+  statusMessage: string
+}
+
+function ImportPreviewScreen({
+  gstreamerStatus,
+  isGenerating,
+  isTauri,
+  onBackHome,
+  onConfirm,
+  onFileSelected,
+  onTextChange,
+  preview,
+  statusMessage,
+}: ImportPreviewScreenProps) {
+  const diagnostics = preview.document.diagnostics
+  const syntaxDiagnostics = diagnostics.filter((diagnostic) => diagnostic.severity !== 'info')
+
+  return (
+    <main className="app-shell app-shell--home">
+      <section className="import-preview panel">
+        <header className="import-preview__topbar">
+          <div className="import-preview__nav">
+            <IconButton icon="arrowLeft" label="첫 화면으로 돌아가기" onClick={onBackHome} />
+            <label
+              aria-label="다른 파일 열기"
+              className="icon-button icon-upload-button"
+              htmlFor="preview-pipeline-file"
+              title="다른 파일 열기"
+            >
+              <Icon name="folderOpen" />
+              <span className="sr-only">다른 파일 열기</span>
+              <input
+                id="preview-pipeline-file"
+                onChange={onFileSelected}
+                type="file"
+                accept=".txt,.pld,.rtf,.pld.rtf"
+              />
+            </label>
+          </div>
+
+          <div className="import-preview__status">
+            <ConnectionBadge label="GStreamer API" status={gstreamerStatus.local} />
+            {preview.remoteHost ? (
+              <ConnectionBadge label="Remote Server" status={gstreamerStatus.remote} />
+            ) : null}
+            <span className="card-chip muted-chip">
+              {isTauri ? '데스크톱 런타임' : '브라우저 미리보기'}
+            </span>
+          </div>
+        </header>
+
+        <section className="import-preview__hero">
+          <div>
+            <div className="eyebrow">파일 미리보기</div>
+            <h1>{preview.sourceName}</h1>
+            <p className="hero-body">
+              토폴로지를 생성하기 전에 파이프라인 원문과 감지된 문제를 확인하세요.
+              필요한 경우 텍스트를 수정한 뒤 `토폴로지 생성`을 누르면 수정본 기준으로
+              캔버스를 엽니다.
+            </p>
+          </div>
+
+          <div className="import-preview__summary">
+            <span className="card-chip">
+              노드 {preview.document.graph.nodes.length}개 / 엣지 {preview.document.graph.edges.length}개
+            </span>
+            <span className={syntaxDiagnostics.length ? 'card-chip severity-warning' : 'card-chip'}>
+              진단 {diagnostics.length}개
+            </span>
+          </div>
+        </section>
+
+        {syntaxDiagnostics.length ? (
+          <aside className="workspace-alert severity-warning">
+            <strong>파이프라인 구문 확인 필요</strong>
+            <span>
+              가능한 범위의 토폴로지는 만들 수 있지만, 파서 진단
+              {syntaxDiagnostics.length}건이 있습니다. 생성 전 원문을 확인해 주세요.
+            </span>
+          </aside>
+        ) : null}
+
+        <textarea
+          className="text-area import-preview__editor"
+          onChange={(event) => onTextChange(event.target.value)}
+          spellCheck={false}
+          value={preview.text}
+        />
+
+        <footer className="import-preview__footer">
+          <span className="status-message">{statusMessage}</span>
+          <button
+            className="primary-button"
+            disabled={isGenerating || !preview.text.trim()}
+            onClick={onConfirm}
+            type="button"
+          >
+            {isGenerating ? '생성 중...' : '토폴로지 생성'}
+          </button>
+        </footer>
+      </section>
+    </main>
+  )
+}
+
+export { ImportPreviewScreen }

--- a/src/features/workspace/SourceTextPanel.tsx
+++ b/src/features/workspace/SourceTextPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useLayoutEffect, useRef } from 'react'
 import type {
   PipelineDiagnostic,
   PipelineDocumentViewModel,
@@ -10,6 +10,7 @@ type SourceTextPanelProps = {
   document: PipelineDocumentViewModel
   isOpen: boolean
   selectedNode: PipelineNodeViewModel | null
+  selectionRevision: number
   onToggle: () => void
 }
 
@@ -74,6 +75,7 @@ function SourceTextPanel({
   document,
   isOpen,
   selectedNode,
+  selectionRevision,
   onToggle,
 }: SourceTextPanelProps) {
   const highlightRef = useRef<HTMLElement | null>(null)
@@ -91,32 +93,47 @@ function SourceTextPanel({
       }
     : { before: text, selected: '', after: '' }
 
-  useEffect(() => {
-    const mark = highlightRef.current
-    const scroller = codeScrollRef.current
-    if (!isOpen || !mark || !scroller) {
+  useLayoutEffect(() => {
+    if (!isOpen) {
       return
     }
 
-    const markRect = mark.getBoundingClientRect()
-    const scrollerRect = scroller.getBoundingClientRect()
-    const targetTop = scroller.scrollTop
-      + markRect.top
-      - scrollerRect.top
-      - (scroller.clientHeight / 2)
-      + (markRect.height / 2)
-    const targetLeft = scroller.scrollLeft
-      + markRect.left
-      - scrollerRect.left
-      - (scroller.clientWidth / 2)
-      + (markRect.width / 2)
+    const frameId = window.requestAnimationFrame(() => {
+      const mark = highlightRef.current
+      const scroller = codeScrollRef.current
+      if (!mark || !scroller) {
+        return
+      }
 
-    scroller.scrollTo({
-      left: Math.max(0, targetLeft),
-      top: Math.max(0, targetTop),
-      behavior: 'smooth',
+      const markRect = mark.getBoundingClientRect()
+      const scrollerRect = scroller.getBoundingClientRect()
+      const targetTop = scroller.scrollTop
+        + markRect.top
+        - scrollerRect.top
+        - (scroller.clientHeight / 2)
+        + (markRect.height / 2)
+      const targetLeft = scroller.scrollLeft
+        + markRect.left
+        - scrollerRect.left
+        - (scroller.clientWidth / 2)
+        + (markRect.width / 2)
+
+      scroller.scrollTo({
+        left: Math.max(0, targetLeft),
+        top: Math.max(0, targetTop),
+        behavior: 'auto',
+      })
     })
-  }, [document.id, isOpen, selectedNode?.id, selectedSpan?.end, selectedSpan?.start])
+
+    return () => window.cancelAnimationFrame(frameId)
+  }, [
+    document.id,
+    isOpen,
+    selectedNode?.id,
+    selectedSpan?.end,
+    selectedSpan?.start,
+    selectionRevision,
+  ])
 
   return (
     <section className={isOpen ? 'source-panel is-open' : 'source-panel'}>

--- a/src/features/workspace/SourceTextPanel.tsx
+++ b/src/features/workspace/SourceTextPanel.tsx
@@ -15,6 +15,12 @@ type SourceTextPanelProps = {
 
 const encoder = new TextEncoder()
 
+function selectedNodeLabel(node: PipelineNodeViewModel) {
+  return node.instanceName
+    ? `${node.instanceName} (${node.factoryName})`
+    : node.factoryName
+}
+
 function byteOffsetToStringIndex(text: string, byteOffset: number) {
   let bytes = 0
   let index = 0
@@ -32,17 +38,31 @@ function byteOffsetToStringIndex(text: string, byteOffset: number) {
   return text.length
 }
 
-function clampSpan(text: string, span?: SourceSpan) {
-  if (!span || typeof span.start !== 'number' || typeof span.end !== 'number') {
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function validSpan(text: string, span?: SourceSpan) {
+  if (!span || !isFiniteNumber(span.start) || !isFiniteNumber(span.end)) {
     return null
   }
 
-  const start = byteOffsetToStringIndex(text, Math.max(0, span.start))
-  const end = byteOffsetToStringIndex(text, Math.max(span.start, span.end))
+  const textByteLength = encoder.encode(text).length
+  if (span.start < 0 || span.start >= span.end || span.end > textByteLength) {
+    return null
+  }
+
+  const start = byteOffsetToStringIndex(text, span.start)
+  const end = byteOffsetToStringIndex(text, span.end)
+  const selected = text.slice(start, end)
+  if (!selected.trim()) {
+    return null
+  }
 
   return {
-    start: Math.min(start, text.length),
-    end: Math.min(Math.max(end, start), text.length),
+    end,
+    selected,
+    start,
   }
 }
 
@@ -57,28 +77,40 @@ function SourceTextPanel({
   onToggle,
 }: SourceTextPanelProps) {
   const highlightRef = useRef<HTMLElement | null>(null)
+  const codeScrollRef = useRef<HTMLPreElement | null>(null)
   const text = document.normalizedText
-  const selectedSpan = clampSpan(text, selectedNode?.sourceSpan)
+  const selectedSpan = validSpan(text, selectedNode?.sourceSpan)
   const diagnostics = syntaxDiagnostics(document.diagnostics)
+  const showHighlightFallback = Boolean(selectedNode && !selectedSpan)
 
   const highlightedText = selectedSpan
     ? {
         before: text.slice(0, selectedSpan.start),
-        selected: text.slice(selectedSpan.start, selectedSpan.end),
+        selected: selectedSpan.selected,
         after: text.slice(selectedSpan.end),
       }
     : { before: text, selected: '', after: '' }
 
   useEffect(() => {
-    if (!isOpen || !highlightRef.current) {
+    const mark = highlightRef.current
+    const scroller = codeScrollRef.current
+    if (!isOpen || !mark || !scroller) {
       return
     }
 
-    highlightRef.current.scrollIntoView({
-      block: 'center',
+    const markRect = mark.getBoundingClientRect()
+    const scrollerRect = scroller.getBoundingClientRect()
+    const targetTop = scroller.scrollTop
+      + markRect.top
+      - scrollerRect.top
+      - (scroller.clientHeight / 2)
+      + (markRect.height / 2)
+
+    scroller.scrollTo({
+      top: Math.max(0, targetTop),
       behavior: 'smooth',
     })
-  }, [isOpen, selectedNode?.id])
+  }, [document.id, isOpen, selectedNode?.id, selectedSpan?.end, selectedSpan?.start])
 
   return (
     <section className={isOpen ? 'source-panel is-open' : 'source-panel'}>
@@ -87,7 +119,8 @@ function SourceTextPanel({
           <strong>Pipeline 원문</strong>
           {selectedNode?.sourceSpan ? (
             <em>
-              선택 위치: {selectedNode.sourceSpan.lineStart}-{selectedNode.sourceSpan.lineEnd}행
+              선택: {selectedNodeLabel(selectedNode)} · {selectedNode.sourceSpan.lineStart}-
+              {selectedNode.sourceSpan.lineEnd}행
             </em>
           ) : (
             <em>선택한 Element의 원문 위치를 함께 확인합니다.</em>
@@ -105,7 +138,14 @@ function SourceTextPanel({
             </div>
           ) : null}
 
-          <pre className="source-panel__code">
+          {showHighlightFallback ? (
+            <div className="source-panel__alert source-panel__alert--highlight">
+              원문 위치를 찾지 못했습니다. 그래프는 유지되지만 이 Element의 source
+              span을 확인해야 합니다.
+            </div>
+          ) : null}
+
+          <pre className="source-panel__code" ref={codeScrollRef}>
             <code>
               <span>{highlightedText.before}</span>
               {highlightedText.selected ? (

--- a/src/features/workspace/SourceTextPanel.tsx
+++ b/src/features/workspace/SourceTextPanel.tsx
@@ -105,8 +105,14 @@ function SourceTextPanel({
       - scrollerRect.top
       - (scroller.clientHeight / 2)
       + (markRect.height / 2)
+    const targetLeft = scroller.scrollLeft
+      + markRect.left
+      - scrollerRect.left
+      - (scroller.clientWidth / 2)
+      + (markRect.width / 2)
 
     scroller.scrollTo({
+      left: Math.max(0, targetLeft),
       top: Math.max(0, targetTop),
       behavior: 'smooth',
     })

--- a/src/features/workspace/WorkspaceShell.tsx
+++ b/src/features/workspace/WorkspaceShell.tsx
@@ -64,6 +64,7 @@ function WorkspaceShell({
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(
     document.graph.nodes[0]?.id ?? null,
   )
+  const [selectionRevision, setSelectionRevision] = useState(0)
   const [activePanel, setActivePanel] = useState<WorkspacePanel | null>(null)
   const [metadataByFactory, setMetadataByFactory] = useState<Record<string, MetadataEntry>>({})
 
@@ -140,6 +141,11 @@ function WorkspaceShell({
 
   function togglePanel(panel: WorkspacePanel) {
     setActivePanel((current) => (current === panel ? null : panel))
+  }
+
+  function handleSelectNode(nodeId: string | null) {
+    setSelectedNodeId(nodeId)
+    setSelectionRevision((current) => current + 1)
   }
 
   return (
@@ -219,7 +225,7 @@ function WorkspaceShell({
             <GraphCanvas
               document={document}
               selectedNodeId={selectedNodeId}
-              onSelectNode={setSelectedNodeId}
+              onSelectNode={handleSelectNode}
             />
           </section>
 
@@ -249,6 +255,7 @@ function WorkspaceShell({
                   document={document}
                   isOpen
                   selectedNode={selectedNode}
+                  selectionRevision={selectionRevision}
                   onToggle={() => setActivePanel(null)}
                 />
               ) : null}

--- a/src/features/workspace/WorkspaceShell.tsx
+++ b/src/features/workspace/WorkspaceShell.tsx
@@ -3,11 +3,12 @@ import {
   inspectLocalElement,
   inspectRemoteElement,
   isTauriRuntime,
-  probeLocalGStreamer,
   type ElementMetadataResponse,
-  type GStreamerProbeResponse,
   type RemoteTargetInput,
 } from '../../app/backend.ts'
+import type { GStreamerRuntimeStatus } from '../../app/status.ts'
+import { ConnectionBadge } from '../../components/ConnectionBadge.tsx'
+import { IconButton } from '../../components/IconButton.tsx'
 import { InspectorPanel } from '../inspector/InspectorPanel.tsx'
 import { GraphCanvas } from '../../graph/GraphCanvas.tsx'
 import { DiagnosticsPanel } from './DiagnosticsPanel.tsx'
@@ -19,9 +20,12 @@ import type {
 
 type WorkspaceShellProps = {
   document: PipelineDocumentViewModel
+  gstreamerStatus: GStreamerRuntimeStatus
   remoteTarget: RemoteTargetInput | null
   onBackHome: () => void
 }
+
+type WorkspacePanel = 'diagnostics' | 'inspector' | 'source'
 
 type MetadataEntry = {
   data?: ElementMetadataResponse
@@ -53,17 +57,14 @@ function getParserStatusLabel(status: PipelineDocumentViewModel['parserStatus'])
 
 function WorkspaceShell({
   document,
+  gstreamerStatus,
   remoteTarget,
   onBackHome,
 }: WorkspaceShellProps) {
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(
     document.graph.nodes[0]?.id ?? null,
   )
-  const [isDiagnosticsOpen, setIsDiagnosticsOpen] = useState(
-    document.diagnostics.some((diagnostic) => diagnostic.severity !== 'info'),
-  )
-  const [isSourceOpen, setIsSourceOpen] = useState(false)
-  const [localProbe, setLocalProbe] = useState<GStreamerProbeResponse | null>(null)
+  const [activePanel, setActivePanel] = useState<WorkspacePanel | null>(null)
   const [metadataByFactory, setMetadataByFactory] = useState<Record<string, MetadataEntry>>({})
 
   const selectedNode = findNode(document, selectedNodeId)
@@ -74,35 +75,17 @@ function WorkspaceShell({
     ? metadataByFactory[selectedNode.factoryName]
     : undefined
   const metadataAuthority =
-    document.sourceKind === 'remote_file' ? '원격 GStreamer' : '로컬 GStreamer'
-
-  useEffect(() => {
-    if (!isTauriRuntime() || document.sourceKind === 'remote_file') {
-      return
-    }
-
-    let isCancelled = false
-    probeLocalGStreamer()
-      .then((response) => {
-        if (!isCancelled) {
-          setLocalProbe(response)
-        }
-      })
-      .catch(() => {
-        if (!isCancelled) {
-          setLocalProbe({
-            available: false,
-            authority: 'local',
-            diagnostic: '로컬 GStreamer 확인에 실패했습니다.',
-            version_output: null,
-          })
-        }
-      })
-
-    return () => {
-      isCancelled = true
-    }
-  }, [document.id, document.sourceKind])
+    remoteTarget ? '원격 GStreamer' : '로컬 GStreamer'
+  const apiStatus = remoteTarget
+    ? {
+        ...gstreamerStatus.remote,
+        host: undefined,
+        message: gstreamerStatus.remote.version
+          ? '원격 GStreamer API 연결됨'
+          : gstreamerStatus.remote.message,
+        port: undefined,
+      }
+    : gstreamerStatus.local
 
   useEffect(() => {
     if (!selectedNode || !isTauriRuntime()) {
@@ -116,7 +99,7 @@ function WorkspaceShell({
 
     let isCancelled = false
     const loader =
-      document.sourceKind === 'remote_file' && remoteTarget
+      remoteTarget
         ? inspectRemoteElement(remoteTarget, selectedNode.factoryName)
         : inspectLocalElement(selectedNode.factoryName)
 
@@ -153,16 +136,18 @@ function WorkspaceShell({
     return () => {
       isCancelled = true
     }
-  }, [document.sourceKind, metadataByFactory, remoteTarget, selectedNode])
+  }, [metadataByFactory, remoteTarget, selectedNode])
+
+  function togglePanel(panel: WorkspacePanel) {
+    setActivePanel((current) => (current === panel ? null : panel))
+  }
 
   return (
     <main className="app-shell app-shell--workspace">
       <section className="workspace-shell">
         <header className="workspace-topbar panel">
           <div className="workspace-topbar__meta">
-            <button className="secondary-button" onClick={onBackHome} type="button">
-              다른 파이프라인 열기
-            </button>
+            <IconButton icon="arrowLeft" label="첫 화면으로 돌아가기" onClick={onBackHome} />
             <div className="workspace-topbar__title">
               <div className="eyebrow">워크스페이스</div>
               <h1>{document.title}</h1>
@@ -171,34 +156,38 @@ function WorkspaceShell({
           </div>
 
           <div className="workspace-topbar__actions">
+            <ConnectionBadge label="GStreamer API" status={apiStatus} />
+            {remoteTarget ? (
+              <ConnectionBadge label="Remote Server" status={gstreamerStatus.remote} />
+            ) : null}
             <span className="card-chip">{document.sourceLabel}</span>
             <span className="card-chip">
               노드 {document.graph.nodes.length}개 / 엣지 {document.graph.edges.length}개
             </span>
             <span className="card-chip">{getParserStatusLabel(document.parserStatus)}</span>
             <span className="card-chip">{metadataAuthority}</span>
-            <button
-              className={
-                isSourceOpen
-                  ? 'secondary-button diagnostics-toggle is-active'
-                  : 'secondary-button diagnostics-toggle'
-              }
-              onClick={() => setIsSourceOpen((current) => !current)}
-              type="button"
-            >
-              Pipeline 원문
-            </button>
-            <button
-              className={
-                isDiagnosticsOpen
-                  ? 'secondary-button diagnostics-toggle is-active'
-                  : 'secondary-button diagnostics-toggle'
-              }
-              onClick={() => setIsDiagnosticsOpen((current) => !current)}
-              type="button"
-            >
-              진단 {document.diagnostics.length}개
-            </button>
+            <div className="workspace-topbar__panel-actions" aria-label="보조 패널">
+              <IconButton
+                active={activePanel === 'inspector'}
+                badge={selectedNode ? '•' : undefined}
+                icon="panelRight"
+                label="인스펙터 열기"
+                onClick={() => togglePanel('inspector')}
+              />
+              <IconButton
+                active={activePanel === 'source'}
+                icon="fileText"
+                label="Pipeline 원문 열기"
+                onClick={() => togglePanel('source')}
+              />
+              <IconButton
+                active={activePanel === 'diagnostics'}
+                badge={document.diagnostics.length || undefined}
+                icon="diagnostics"
+                label="파서 진단 열기"
+                onClick={() => togglePanel('diagnostics')}
+              />
+            </div>
           </div>
         </header>
 
@@ -213,41 +202,66 @@ function WorkspaceShell({
           </aside>
         ) : null}
 
-        {localProbe && !localProbe.available ? (
+        {gstreamerStatus.local.state === 'failed' && !remoteTarget ? (
           <aside className="workspace-alert severity-info">
             <strong>로컬 GStreamer 정보 없음</strong>
             <span>
-              이 장비에서 `gst-inspect-1.0`을 찾지 못했습니다. 토폴로지는 텍스트 파서
+              {gstreamerStatus.local.message ?? '이 장비에서 `gst-inspect-1.0`을 찾지 못했습니다.'}
+              {' '}
+              토폴로지는 텍스트 파서
               기준으로 계속 표시하고, Element 내부 정보는 설치 후 확인할 수 있습니다.
             </span>
           </aside>
         ) : null}
 
-        <div className="workspace-grid">
+        <div className={activePanel ? 'workspace-grid workspace-grid--drawer-open' : 'workspace-grid'}>
           <section className="workspace-main">
             <GraphCanvas
               document={document}
               selectedNodeId={selectedNodeId}
               onSelectNode={setSelectedNodeId}
             />
-            <SourceTextPanel
-              document={document}
-              isOpen={isSourceOpen}
-              selectedNode={selectedNode}
-              onToggle={() => setIsSourceOpen((current) => !current)}
-            />
-            <DiagnosticsPanel
-              diagnostics={document.diagnostics}
-              isOpen={isDiagnosticsOpen}
-              onToggle={() => setIsDiagnosticsOpen((current) => !current)}
-            />
           </section>
 
-          <InspectorPanel
-            document={document}
-            metadata={selectedMetadata}
-            selectedNode={selectedNode}
-          />
+          {activePanel ? (
+            <aside className="workspace-drawer">
+              <div className="workspace-drawer__header">
+                <span className="card-chip muted-chip">
+                  {activePanel === 'inspector'
+                    ? '인스펙터'
+                    : activePanel === 'source'
+                      ? 'Pipeline 원문'
+                      : '파서 진단'}
+                </span>
+                <IconButton icon="close" label="패널 닫기" onClick={() => setActivePanel(null)} />
+              </div>
+
+              {activePanel === 'inspector' ? (
+                <InspectorPanel
+                  document={document}
+                  metadata={selectedMetadata}
+                  selectedNode={selectedNode}
+                />
+              ) : null}
+
+              {activePanel === 'source' ? (
+                <SourceTextPanel
+                  document={document}
+                  isOpen
+                  selectedNode={selectedNode}
+                  onToggle={() => setActivePanel(null)}
+                />
+              ) : null}
+
+              {activePanel === 'diagnostics' ? (
+                <DiagnosticsPanel
+                  diagnostics={document.diagnostics}
+                  isOpen
+                  onToggle={() => setActivePanel(null)}
+                />
+              ) : null}
+            </aside>
+          ) : null}
         </div>
       </section>
     </main>

--- a/src/graph/fromBackend.ts
+++ b/src/graph/fromBackend.ts
@@ -18,6 +18,7 @@ import type {
 const elk = new ELK()
 const DEFAULT_NODE_HEIGHT = 118
 const DEFAULT_NODE_WIDTH = 220
+const encoder = new TextEncoder()
 
 function sourceKindLabel(sourceKind: BackendPipelineDocument['source_kind']) {
   switch (sourceKind) {
@@ -98,16 +99,36 @@ function countLineBreaks(text: string, index: number) {
   return line
 }
 
+function byteOffsetToStringIndex(text: string, byteOffset: number) {
+  let bytes = 0
+  let index = 0
+
+  for (const char of text) {
+    const nextBytes = bytes + encoder.encode(char).length
+    if (nextBytes > byteOffset) {
+      return index
+    }
+
+    bytes = nextBytes
+    index += char.length
+  }
+
+  return text.length
+}
+
 function toLineSpan(text: string, span: BackendSourceSpan | undefined | null) {
   if (!span) {
     return undefined
   }
 
+  const startIndex = byteOffsetToStringIndex(text, Math.max(0, span.start))
+  const endIndex = byteOffsetToStringIndex(text, Math.max(span.start, span.end))
+
   return {
     start: span.start,
     end: span.end,
-    lineStart: countLineBreaks(text, span.start),
-    lineEnd: countLineBreaks(text, span.end),
+    lineStart: countLineBreaks(text, startIndex),
+    lineEnd: countLineBreaks(text, endIndex),
   }
 }
 

--- a/src/styles/app-shell.css
+++ b/src/styles/app-shell.css
@@ -10,7 +10,7 @@
 
 .app-shell--home {
   height: 100svh;
-  overflow: hidden;
+  overflow: auto;
 }
 
 .sr-only {
@@ -54,6 +54,36 @@
   background:
     linear-gradient(180deg, rgba(246, 250, 255, 0.96), rgba(233, 241, 250, 0.84)),
     linear-gradient(135deg, rgba(21, 141, 255, 0.07), transparent 42%);
+}
+
+.launcher-card--single {
+  width: min(1540px, 100%);
+  min-height: calc(100svh - 40px);
+  max-height: none;
+  grid-template-rows: auto minmax(0, 1fr);
+  padding: clamp(24px, 3svh, 42px);
+}
+
+.launcher-card__topbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.home-toolbar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.launcher-card__main {
+  display: grid;
+  min-height: 0;
+  gap: 18px;
+  grid-template-rows: minmax(300px, 1fr) auto auto;
 }
 
 .launcher-card__header,
@@ -490,6 +520,56 @@
 .text-area {
   min-height: clamp(110px, 15svh, 170px);
   resize: vertical;
+}
+
+.pipeline-input {
+  min-height: min(56svh, 560px);
+  font-family: var(--font-mono);
+  font-size: 0.96rem;
+  line-height: 1.7;
+  resize: none;
+}
+
+.topology-generate-button {
+  min-height: 66px;
+  width: 100%;
+  font-size: 1.08rem;
+}
+
+.home-status-line,
+.remote-status-line {
+  margin: 0;
+  color: var(--text-soft);
+  font-size: 0.92rem;
+  font-weight: 700;
+  line-height: 1.5;
+}
+
+.remote-modal__card--compact {
+  width: min(640px, 100%);
+}
+
+.remote-card--compact {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.remote-card--compact .remote-card__grid {
+  grid-template-columns: minmax(180px, 1.3fr) minmax(100px, 0.7fr);
+}
+
+.remote-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.remote-connect-button {
+  min-height: 48px;
+  min-width: 128px;
 }
 
 .text-field:focus,
@@ -1054,6 +1134,10 @@
     overflow: auto;
   }
 
+  .launcher-card--single {
+    min-height: calc(100svh - 40px);
+  }
+
   .remote-card__grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -1144,6 +1228,24 @@
     max-height: none;
   }
 
+  .launcher-card--single {
+    min-height: calc(100svh - 24px);
+  }
+
+  .launcher-card__topbar,
+  .remote-card__footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .home-toolbar {
+    justify-content: flex-start;
+  }
+
+  .pipeline-input {
+    min-height: 280px;
+  }
+
   .launcher-card h1,
   .workspace-topbar h1 {
     font-size: clamp(1.9rem, 9vw, 2.8rem);
@@ -1159,6 +1261,10 @@
   }
 
   .remote-card__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .remote-card--compact .remote-card__grid {
     grid-template-columns: 1fr;
   }
 

--- a/src/styles/app-shell.css
+++ b/src/styles/app-shell.css
@@ -751,6 +751,22 @@
   max-height: none;
 }
 
+.workspace-drawer .source-panel {
+  overflow: hidden;
+}
+
+.workspace-drawer .source-panel__body {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.workspace-drawer .source-panel__code {
+  min-height: 0;
+  flex: 1 1 auto;
+  overflow: auto;
+}
+
 .workspace-main .canvas-panel {
   min-height: 0;
   padding: 0;
@@ -830,6 +846,8 @@
   border-radius: 24px;
   background: rgba(249, 252, 255, 0.88);
   box-shadow: var(--shadow-soft);
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
 }
 
 .source-panel__toggle {

--- a/src/styles/app-shell.css
+++ b/src/styles/app-shell.css
@@ -13,6 +13,18 @@
   overflow: hidden;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .panel,
 .workspace-panel {
   background: var(--surface-base);
@@ -113,7 +125,8 @@
 
 .primary-button,
 .secondary-button,
-.upload-action {
+.upload-action,
+.icon-button {
   border: 0;
   border-radius: 16px;
   transition:
@@ -143,7 +156,8 @@
 
 .primary-button:hover,
 .secondary-button:hover,
-.upload-action:hover {
+.upload-action:hover,
+.icon-button:hover {
   transform: translateY(-1px);
 }
 
@@ -168,6 +182,135 @@
   inset: 0;
   opacity: 0;
   cursor: pointer;
+}
+
+.ui-icon {
+  width: 20px;
+  height: 20px;
+}
+
+.icon-button {
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  width: 46px;
+  height: 46px;
+  padding: 0;
+  border: 1px solid var(--stroke-soft);
+  background: rgba(249, 252, 255, 0.82);
+  color: var(--ink-strong);
+  box-shadow: var(--shadow-soft);
+}
+
+.icon-button.is-active,
+.icon-button--primary {
+  border-color: rgba(21, 141, 255, 0.22);
+  background: var(--accent-primary-soft);
+  color: var(--accent-primary);
+}
+
+.icon-button--primary {
+  background: linear-gradient(135deg, var(--accent-primary), #46c8ff);
+  color: #fff;
+}
+
+.icon-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  transform: none;
+}
+
+.icon-button__badge {
+  position: absolute;
+  top: -7px;
+  right: -7px;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border: 2px solid rgba(247, 251, 255, 0.95);
+  border-radius: 999px;
+  background: #de5c57;
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-size: 0.68rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.icon-upload-button {
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.icon-upload-button input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.connection-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  min-height: 38px;
+  max-width: 260px;
+  padding: 7px 11px;
+  border: 1px solid var(--stroke-soft);
+  border-radius: 999px;
+  background: rgba(249, 252, 255, 0.82);
+  color: var(--text-soft);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.66);
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: #94a3b8;
+  box-shadow: 0 0 0 4px rgba(148, 163, 184, 0.16);
+}
+
+.connection-badge--connected .status-dot {
+  background: #20b26b;
+  box-shadow: 0 0 0 4px rgba(32, 178, 107, 0.16);
+}
+
+.connection-badge--checking .status-dot {
+  background: #e8a928;
+  box-shadow: 0 0 0 4px rgba(232, 169, 40, 0.18);
+}
+
+.connection-badge--failed .status-dot {
+  background: #de5c57;
+  box-shadow: 0 0 0 4px rgba(222, 92, 87, 0.16);
+}
+
+.connection-badge__copy {
+  min-width: 0;
+  display: grid;
+  gap: 1px;
+}
+
+.connection-badge__copy strong,
+.connection-badge__copy em {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.connection-badge__copy strong {
+  color: var(--ink-strong);
+  font-size: 0.72rem;
+}
+
+.connection-badge__copy em {
+  color: var(--text-soft);
+  font-size: 0.72rem;
+  font-style: normal;
+  font-weight: 700;
 }
 
 .launcher-card__actions {
@@ -230,6 +373,93 @@
   align-items: center;
 }
 
+.remote-entry {
+  display: grid;
+  gap: 12px;
+  align-content: start;
+  padding: 16px;
+  border: 1px solid rgba(23, 49, 82, 0.1);
+  border-radius: 22px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(235, 244, 252, 0.74)),
+    radial-gradient(circle at top right, rgba(21, 141, 255, 0.1), transparent 32%);
+}
+
+.remote-entry__button {
+  width: 100%;
+  border: 0;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+}
+
+.remote-entry__button strong,
+.remote-entry__button em {
+  display: block;
+}
+
+.remote-entry__button strong {
+  color: var(--ink-strong);
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+}
+
+.remote-entry__button em {
+  color: var(--text-soft);
+  font-size: 0.9rem;
+  font-style: normal;
+  line-height: 1.45;
+}
+
+.remote-entry__icon {
+  display: grid;
+  place-items: center;
+  width: 46px;
+  height: 46px;
+  flex: 0 0 auto;
+  border-radius: 16px;
+  background: var(--accent-primary-soft);
+  color: var(--accent-primary);
+}
+
+.remote-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  background: rgba(9, 23, 42, 0.28);
+  backdrop-filter: blur(12px);
+}
+
+.remote-modal__card {
+  width: min(760px, 100%);
+  max-height: calc(100svh - 40px);
+  overflow: auto;
+  padding: 22px;
+  display: grid;
+  gap: 18px;
+}
+
+.remote-modal__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.remote-modal__header h2 {
+  color: var(--ink-strong);
+  font-family: var(--font-display);
+  font-size: 1.8rem;
+  letter-spacing: -0.04em;
+}
+
 .launcher-card__footer {
   display: grid;
   gap: 12px;
@@ -266,7 +496,9 @@
 .text-area:focus,
 .secondary-button:focus-visible,
 .primary-button:focus-visible,
-.diagnostics-panel__toggle:focus-visible {
+.diagnostics-panel__toggle:focus-visible,
+.icon-button:focus-visible,
+.remote-entry__button:focus-visible {
   outline: 2px solid rgba(21, 141, 255, 0.28);
   outline-offset: 2px;
 }
@@ -366,6 +598,16 @@
   justify-content: flex-end;
 }
 
+.workspace-topbar__panel-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px;
+  border: 1px solid rgba(23, 49, 82, 0.1);
+  border-radius: 20px;
+  background: rgba(235, 244, 252, 0.74);
+}
+
 .diagnostics-toggle.is-active {
   background: var(--accent-primary-soft);
   border-color: rgba(21, 141, 255, 0.22);
@@ -384,16 +626,49 @@
   display: grid;
   flex: 1 1 auto;
   gap: 16px;
-  grid-template-columns: minmax(0, 1fr) 340px;
+  grid-template-columns: minmax(0, 1fr);
   min-height: 0;
   overflow: hidden;
+}
+
+.workspace-grid--drawer-open {
+  grid-template-columns: minmax(0, 1fr) minmax(340px, 400px);
 }
 
 .workspace-main {
   min-height: 0;
   min-width: 0;
-  grid-template-rows: minmax(0, 1fr) auto auto;
+  grid-template-rows: minmax(0, 1fr);
   overflow: hidden;
+}
+
+.workspace-drawer {
+  min-height: 0;
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 12px;
+}
+
+.workspace-drawer__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.workspace-drawer > .workspace-panel,
+.workspace-drawer .source-panel,
+.workspace-drawer .diagnostics-panel {
+  min-height: 0;
+  max-height: none;
+  height: 100%;
+  overflow: auto;
+}
+
+.workspace-drawer .source-panel__code,
+.workspace-drawer .diagnostics-panel__content {
+  max-height: none;
 }
 
 .workspace-main .canvas-panel {
@@ -719,6 +994,55 @@
   gap: 6px;
 }
 
+.import-preview {
+  width: min(1180px, 100%);
+  max-height: calc(100svh - 40px);
+  margin: 0 auto;
+  padding: clamp(18px, 2.4svh, 28px);
+  display: grid;
+  gap: 18px;
+  overflow: auto;
+  background:
+    linear-gradient(180deg, rgba(246, 250, 255, 0.96), rgba(233, 241, 250, 0.88)),
+    radial-gradient(circle at top right, rgba(21, 141, 255, 0.1), transparent 30%);
+}
+
+.import-preview__topbar,
+.import-preview__footer,
+.import-preview__status,
+.import-preview__nav,
+.import-preview__summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.import-preview__topbar,
+.import-preview__footer {
+  justify-content: space-between;
+}
+
+.import-preview__hero {
+  display: grid;
+  gap: 16px;
+}
+
+.import-preview__summary {
+  flex-wrap: wrap;
+}
+
+.import-preview__editor {
+  min-height: min(48svh, 520px);
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  line-height: 1.6;
+  resize: none;
+}
+
+.import-preview__footer {
+  align-items: center;
+}
+
 @media (max-width: 1180px) {
   .workspace-grid {
     grid-template-columns: 1fr;
@@ -780,7 +1104,7 @@
     grid-row: 1;
   }
 
-  .remote-card {
+  .remote-entry {
     grid-column: 2;
     grid-row: 2 / span 2;
   }

--- a/src/styles/app-shell.css
+++ b/src/styles/app-shell.css
@@ -798,6 +798,11 @@
   font-weight: 700;
 }
 
+.source-panel__alert--highlight {
+  background: rgba(220, 238, 255, 0.94);
+  color: var(--accent-primary);
+}
+
 .source-panel__code {
   max-height: min(14svh, 140px);
   margin: 0;


### PR DESCRIPTION
## Summary

Sprint 04 implements the local-first UI/UX refinements, workspace drawer workflow, and long RTF source-highlight stabilization for GStreamer Topology.

## Changes

- Simplified the home screen into a larger pipeline text input and primary topology generation flow.
- Moved Local/Remote actions into compact top-right icons and simplified the Remote Server modal.
- Added connection badges for GStreamer API and Remote Server status/version visibility.
- Added file import preview/text normalization flow and preserved local paste generation.
- Converted workspace Inspector, Pipeline source, and Parser diagnostics into icon-driven drawers.
- Improved long RTF source span bounds tests and source drawer highlight/scroll reliability.
- Documented Sprint 04 process and GitHub project workflow updates.

## Validation

- `git diff --check`
- `npm run lint`
- `npm run build`
- `cd src-tauri && cargo test`
- `npm run tauri:dev` native process/window confirmation
- User QA completed across Sprint 04 board items

## Notes

A small residual intermittent source-highlight/canvas UX issue was accepted for Sprint 04 and captured as follow-up issue #19 for the next canvas UI sprint.

Closes #13
Closes #14
Closes #16
Closes #17
Closes #18
