### PR TITLE
Sprint 07: Canvas routing, source focus, export, and Windows launch fixes

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -73,19 +73,6 @@ jobs:
           releaseDraft: true
           prerelease: true
 
-      - name: Generate release checksums
-        shell: bash
-        run: |
-          bundle_dir="src-tauri/target/release/bundle"
-          checksum_file="$RUNNER_TEMP/SHA256SUMS-${{ matrix.name }}.txt"
-          find "$bundle_dir" -type f \( -name "*.dmg" -o -name "*.msi" -o -name "*.exe" -o -name "*.AppImage" -o -name "*.deb" -o -name "*.tar.gz" \) -print0 \
-            | sort -z \
-            | xargs -0 sha256sum > "$checksum_file"
-          cat "$checksum_file"
-          gh release upload "${{ github.event.inputs.tag || github.ref_name }}" "$checksum_file" --repo "$GITHUB_REPOSITORY" --clobber
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Verify Windows runtime bundle assumptions
         if: runner.os == 'Windows'
         shell: pwsh
@@ -108,6 +95,15 @@ jobs:
           }
           Write-Host "Windows executable: $($exe.FullName)"
 
+          $bytes = [System.IO.File]::ReadAllBytes($exe.FullName)
+          $peOffset = [System.BitConverter]::ToInt32($bytes, 0x3c)
+          $subsystemOffset = $peOffset + 24 + 0x44
+          $subsystem = [System.BitConverter]::ToUInt16($bytes, $subsystemOffset)
+          if ($subsystem -ne 2) {
+            throw "Windows executable subsystem must be GUI/Windows (2), got $subsystem. A console window will appear for subsystem 3."
+          }
+          Write-Host "Windows executable subsystem is GUI/Windows."
+
           $mt = Get-Command mt.exe -ErrorAction SilentlyContinue
           if (-not $mt) {
             Write-Warning "mt.exe is not available on PATH; skipping embedded manifest extraction."
@@ -121,6 +117,19 @@ jobs:
             throw "Embedded Windows manifest is missing the Common Controls v6 dependency."
           }
           Write-Host "Embedded Windows manifest contains Common Controls v6."
+
+      - name: Generate release checksums
+        shell: bash
+        run: |
+          bundle_dir="src-tauri/target/release/bundle"
+          checksum_file="$RUNNER_TEMP/SHA256SUMS-${{ matrix.name }}.txt"
+          find "$bundle_dir" -type f \( -name "*.dmg" -o -name "*.msi" -o -name "*.exe" -o -name "*.AppImage" -o -name "*.deb" -o -name "*.tar.gz" \) -print0 \
+            | sort -z \
+            | xargs -0 sha256sum > "$checksum_file"
+          cat "$checksum_file"
+          gh release upload "${{ github.event.inputs.tag || github.ref_name }}" "$checksum_file" --repo "$GITHUB_REPOSITORY" --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: List generated bundles
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,18 @@ Do not repeat the `tauri:dev` verification mistake from `2026-04-22`.
 - If full launch cannot be confirmed, report `launch unverified`, not
   `working`.
 
+Do not repeat the Sprint 07 closeout release omission.
+
+- A sprint is not fully closed just because user QA passed, issues are `Done`,
+  and the PR is opened.
+- Before closeout, trigger the `Desktop Release` workflow from the sprint
+  branch and confirm Windows and Linux installer assets exist in the draft
+  Release.
+- Record the workflow run URL, Release URL, installer names, and checksum files
+  in the PR or handoff.
+- If installer generation is incomplete, report `release unverified`, not
+  `complete`.
+
 ## Primary Samples
 
 Use these as canonical fixtures during parser and workspace development:

--- a/README.md
+++ b/README.md
@@ -91,9 +91,16 @@ Windows release note:
 - Windows 실행 파일은 Tauri build script가 삽입하는 Common Controls v6 manifest에
   의존합니다. 이 manifest가 없으면 Windows 11에서도 `TaskDialogIndirect` entry
   point 오류로 앱이 첫 화면 전에 종료될 수 있습니다.
+- Release 빌드는 Windows GUI subsystem으로 생성되어야 합니다. Console subsystem으로
+  생성되면 앱 실행 시 명령프롬프트 창이 함께 뜨고, 그 창을 닫으면 앱도 종료됩니다.
+  `Desktop Release` workflow는 빌드된 `.exe`의 PE subsystem 값이 GUI/Windows인지
+  확인합니다.
 - `Desktop Release` workflow는 Windows bundle 안에 `comctl32.dll`이 포함되어
   시스템 Common Controls v6를 가리지 않는지 확인하고, 가능하면 embedded manifest에
   Common Controls v6 dependency가 있는지도 확인합니다.
+- 명령프롬프트 창이 없는 Release build에서는 stdout/stderr가 콘솔에 표시되지 않을
+  수 있습니다. 문제 재현 시 화면 캡처, 사용한 설치 파일명, 실행 경로를 GitHub
+  Issue에 첨부합니다. 현재 앱은 별도 log file을 자동 생성하지 않습니다.
 
 GStreamer discovery note:
 - macOS에서 `.dmg`로 설치한 앱을 Finder에서 실행하면 interactive shell `PATH`를

--- a/docs/PROCESS_POLICY.md
+++ b/docs/PROCESS_POLICY.md
@@ -79,6 +79,12 @@ Branch workflow:
 Sprint closeout:
 - Move completed issues to `Done` only after code is committed, pushed, and the
   user-visible QA path has passed.
+- Before calling a sprint complete, trigger the `Desktop Release` workflow for
+  the sprint branch and confirm the draft Release contains Windows and Linux
+  installer assets plus checksum files.
+- Record the Release URL, workflow run URL, and generated asset names in the
+  sprint PR or handoff. If the Release workflow fails or is still running,
+  report the sprint as `release unverified`, not complete.
 - The user is expected to inspect `In Progress` issues in the active sprint
   Project, run the checklist in each issue, move passing issues to `Done`, and
   leave comments on issues that fail.

--- a/docs/SPRINT_07_PREP.md
+++ b/docs/SPRINT_07_PREP.md
@@ -23,16 +23,15 @@ Sprint board items:
 - `#33` `스프린트 07: Windows 11 실행 시 명령프롬프트 창 제거`
 - `#34` `스프린트 07: Canvas Edge 라우팅과 Multi-port 표시 개선`
 - `#35` `스프린트 07: Pipeline 원문 클릭 시 Canvas Element 선택`
-- `#36` `스프린트 07 Optional: Update 알림 버튼 도입 검토`
 
 Setup completed:
-- `#25`, `#33`, `#34`, `#35`, and `#36` are on the parent board.
-- `#25`, `#33`, `#34`, `#35`, and `#36` are on the `Sprint 07` Project.
-- `#25`, `#33`, `#34`, `#35`, and `#36` have the `sprint-07` label.
+- `#25`, `#33`, `#34`, and `#35` are on the parent board.
+- `#25`, `#33`, `#34`, and `#35` are on the `Sprint 07` Project.
+- `#25`, `#33`, `#34`, and `#35` have the `sprint-07` label.
 - Sprint-specific planning comments were added to the active issues in Korean.
 - `#25`, `#33`, `#34`, and `#35` are active implementation items.
-- `#36` is an Optional design/technical review item, not a fake Update button
-  implementation.
+- `#36` was closed as not planned and removed from the Sprint 07 boards because
+  Update notification/update installation is not needed for the current QA goal.
 
 ## Expected Sprint Theme
 
@@ -123,16 +122,6 @@ Sprint 07 outcome:
   Inspector, and connected Edge highlight.
 - Source formatting and diagnostic focus behavior remain intact.
 
-### `#36` Optional Update notice button review
-
-Priority:
-- `P2`, Optional
-
-Sprint 07 outcome:
-- Keep this as a design/technical spike until updater manifest, signing, and
-  release QA policy are defined.
-- Do not add a fake `Update` button that cannot safely update the app.
-
 ## Recommended Implementation Order
 
 1. `#34` Canvas Edge routing and multi-port display.
@@ -146,9 +135,6 @@ Sprint 07 outcome:
 4. `#25` full topology export.
    - This is the larger functional slice and should be fixture-driven with
      `01`, `26`, and `27` pipeline files.
-5. `#36` Optional Update notice button review.
-   - Treat as a technical spike unless the release/signing requirements become
-     concrete.
 
 ## Expert Loop Plan
 

--- a/docs/SPRINT_07_PREP.md
+++ b/docs/SPRINT_07_PREP.md
@@ -30,7 +30,7 @@ Setup completed:
 - `#25`, `#33`, `#34`, `#35`, and `#36` are on the `Sprint 07` Project.
 - `#25`, `#33`, `#34`, `#35`, and `#36` have the `sprint-07` label.
 - Sprint-specific planning comments were added to the active issues in Korean.
-- `#34` and `#35` are active implementation items.
+- `#25`, `#33`, `#34`, and `#35` are active implementation items.
 - `#36` is an Optional design/technical review item, not a fake Update button
   implementation.
 
@@ -66,6 +66,8 @@ Sprint 07 outcome:
 - PNG and JPG files are non-empty and include off-screen graph content.
 - Canvas controls, minimap, status badges, and other UI chrome are excluded
   from the exported image.
+- Very large exports may be scaled down to avoid browser canvas size and memory
+  limits, while preserving the full graph bounds.
 - `fixtures/pipelines/26_release_record_smoothing.pld` and
   `fixtures/pipelines/27_pipmux.pld` are used as large-graph verification
   samples.
@@ -83,6 +85,8 @@ User evidence:
 Sprint 07 outcome:
 - Windows Release builds run as GUI apps without a console window.
 - Start Menu shortcut and direct exe launch both open only the GUI.
+- The release workflow validates the built Windows exe subsystem so console
+  subsystem regressions fail CI before publishing.
 - A fallback way to collect diagnostics is documented because the console will
   no longer be visible.
 

--- a/docs/SPRINT_07_PREP.md
+++ b/docs/SPRINT_07_PREP.md
@@ -1,0 +1,140 @@
+# Sprint 07 Preparation
+
+Date: 2026-05-05
+
+Branch:
+- `sprint_07`
+
+Base:
+- `main` after Sprint 06 merge commit `79f7e55`
+
+## Sprint Setup Status
+
+GitHub Project note:
+- Parent board: `GStreamer Topology Sprint Board`
+- Sprint execution board: `Sprint 07`
+- Project URL: `https://github.com/users/slayellow/projects/5`
+- The `Sprint 07` Project is linked to the `GStreamer-Topology` repository.
+- Status field uses `Todo`, `In Progress`, and `Done`.
+- Sprint label: `sprint-07`
+
+Sprint board items:
+- `#25` `스프린트 07: 토폴로지 Export PNG/JPG 전체 저장 기능`
+- `#33` `스프린트 07: Windows 11 실행 시 명령프롬프트 창 제거`
+
+Setup completed:
+- `#25` and `#33` are on the parent board.
+- `#25` and `#33` are on the `Sprint 07` Project.
+- `#25` and `#33` have the `sprint-07` label.
+- Sprint-specific planning comments were added to both issues in Korean.
+- Both issues are currently in `Todo`.
+
+## Expected Sprint Theme
+
+Sprint 07 should focus on post-release feedback and one carry-over usability
+gap from Sprint 06.
+
+The sprint should answer two practical questions:
+- Can exported topology images include the full graph, not only the visible
+  viewport?
+- Can the Windows installer launch like a normal GUI desktop app without a
+  console window?
+
+## Issue Triage
+
+### `#25` Full topology PNG/JPG export
+
+Priority:
+- `P1`, carry-over from Sprint 06
+
+User evidence:
+- Sprint 06 export saved only the currently visible canvas viewport.
+- The expected behavior is exporting the entire topology graph bounds,
+  including off-screen nodes, edges, edge labels, and caps labels.
+
+Sprint 07 outcome:
+- Export defaults to full topology graph bounds.
+- PNG and JPG files are non-empty and include off-screen graph content.
+- Canvas controls, minimap, status badges, and other UI chrome are excluded
+  from the exported image.
+- `fixtures/pipelines/26_release_record_smoothing.pld` and
+  `fixtures/pipelines/27_pipmux.pld` are used as large-graph verification
+  samples.
+
+### `#33` Windows console window removal
+
+Priority:
+- `P2`
+
+User evidence:
+- On Windows 11, launching the installed MSI build opens both the GUI and a
+  command prompt window.
+- Closing the command prompt also terminates the app.
+
+Sprint 07 outcome:
+- Windows Release builds run as GUI apps without a console window.
+- Start Menu shortcut and direct exe launch both open only the GUI.
+- A fallback way to collect diagnostics is documented because the console will
+  no longer be visible.
+
+## Recommended Implementation Order
+
+1. `#33` Windows console window removal.
+   - This is likely a small packaging/build setting change and should reduce
+     friction before the next Windows team QA pass.
+2. `#25` full topology export.
+   - This is the larger functional slice and should be fixture-driven with
+     `01`, `26`, and `27` pipeline files.
+
+## Expert Loop Plan
+
+For each substantial implementation slice, use the established role contract:
+
+Atlas:
+- Restate the user-visible goal.
+- Keep the slice small.
+- Define acceptance criteria, verification steps, and stop conditions.
+
+Forge:
+- Implement only the active issue.
+- Avoid broad refactors.
+- Preserve parser source-span mapping and partial-success diagnostics.
+
+Loom:
+- Check information hierarchy and feedback text.
+- Keep the Technical Canvas direction and avoid hiding important status.
+
+Beacon:
+- Verify the slice against issue criteria.
+- Record internal QA results as a Korean comment on the matching GitHub issue.
+- Explicitly state what remains unverified for user QA.
+
+## Verification Standard
+
+Before handing Sprint 07 work to the user for QA, run the relevant subset of:
+- `git diff --check`
+- `npm run lint`
+- `npm run build`
+- `cd src-tauri && cargo test`
+- `npm run tauri:build`
+
+For export-related issues:
+- Verify small and large fixtures.
+- Confirm saved files are non-empty.
+- Confirm full graph bounds are included, not only the current viewport.
+- State whether visual quality was internally verified or left to user QA.
+
+For Windows packaging issues:
+- Verify source configuration and build output as far as possible locally.
+- Use GitHub Actions Release workflow logs when artifacts are generated.
+- Do not claim Windows 11 launch success unless Windows user QA or a real
+  Windows execution environment confirms it.
+
+## Handoff Expectation
+
+At every Sprint 07 handoff, report:
+- which issue was worked
+- what changed
+- what internal checks passed
+- what remains unverified
+- which issue needs user QA next

--- a/docs/SPRINT_07_PREP.md
+++ b/docs/SPRINT_07_PREP.md
@@ -21,24 +21,33 @@ GitHub Project note:
 Sprint board items:
 - `#25` `스프린트 07: 토폴로지 Export PNG/JPG 전체 저장 기능`
 - `#33` `스프린트 07: Windows 11 실행 시 명령프롬프트 창 제거`
+- `#34` `스프린트 07: Canvas Edge 라우팅과 Multi-port 표시 개선`
+- `#35` `스프린트 07: Pipeline 원문 클릭 시 Canvas Element 선택`
+- `#36` `스프린트 07 Optional: Update 알림 버튼 도입 검토`
 
 Setup completed:
-- `#25` and `#33` are on the parent board.
-- `#25` and `#33` are on the `Sprint 07` Project.
-- `#25` and `#33` have the `sprint-07` label.
-- Sprint-specific planning comments were added to both issues in Korean.
-- Both issues are currently in `Todo`.
+- `#25`, `#33`, `#34`, `#35`, and `#36` are on the parent board.
+- `#25`, `#33`, `#34`, `#35`, and `#36` are on the `Sprint 07` Project.
+- `#25`, `#33`, `#34`, `#35`, and `#36` have the `sprint-07` label.
+- Sprint-specific planning comments were added to the active issues in Korean.
+- `#34` and `#35` are active implementation items.
+- `#36` is an Optional design/technical review item, not a fake Update button
+  implementation.
 
 ## Expected Sprint Theme
 
 Sprint 07 should focus on post-release feedback and one carry-over usability
 gap from Sprint 06.
 
-The sprint should answer two practical questions:
+The sprint should answer these practical questions:
 - Can exported topology images include the full graph, not only the visible
   viewport?
 - Can the Windows installer launch like a normal GUI desktop app without a
   console window?
+- Can large canvas Edge routing remain readable when one Element has multiple
+  SRC/SINK connections?
+- Can users click Pipeline source text to select the corresponding Canvas
+  Element?
 
 ## Issue Triage
 
@@ -77,14 +86,65 @@ Sprint 07 outcome:
 - A fallback way to collect diagnostics is documented because the console will
   no longer be visible.
 
+### `#34` Canvas Edge routing and multi-port display
+
+Priority:
+- `P1`
+
+User evidence:
+- Edge lines can visually pass over Element cards.
+- Multiple SRC/SINK connections can collapse into one central point, making
+  tee/funnel/request-pad style graphs harder to read.
+
+Sprint 07 outcome:
+- Edge endpoints are distributed across left/right node rails instead of a
+  single center handle.
+- Selected nodes emphasize connected Edges and connected port endpoints.
+- Element labels and factory names remain readable.
+- This improves readability but does not claim full edge crossing
+  minimization.
+
+### `#35` Pipeline source click selects Canvas Element
+
+Priority:
+- `P1`
+
+User evidence:
+- Canvas-to-source highlighting exists, but source-to-canvas selection is
+  missing.
+
+Sprint 07 outcome:
+- Source panel renders valid Element source spans as clickable text ranges.
+- Clicking or keyboard-selecting a source range updates Canvas selection,
+  Inspector, and connected Edge highlight.
+- Source formatting and diagnostic focus behavior remain intact.
+
+### `#36` Optional Update notice button review
+
+Priority:
+- `P2`, Optional
+
+Sprint 07 outcome:
+- Keep this as a design/technical spike until updater manifest, signing, and
+  release QA policy are defined.
+- Do not add a fake `Update` button that cannot safely update the app.
+
 ## Recommended Implementation Order
 
-1. `#33` Windows console window removal.
+1. `#34` Canvas Edge routing and multi-port display.
+   - This directly addresses the latest canvas readability feedback and can be
+     verified with existing fixtures.
+2. `#35` Pipeline source click selects Canvas Element.
+   - This completes the bidirectional source/canvas selection workflow.
+3. `#33` Windows console window removal.
    - This is likely a small packaging/build setting change and should reduce
      friction before the next Windows team QA pass.
-2. `#25` full topology export.
+4. `#25` full topology export.
    - This is the larger functional slice and should be fixture-driven with
      `01`, `26`, and `27` pipeline files.
+5. `#36` Optional Update notice button review.
+   - Treat as a technical spike unless the release/signing requirements become
+     concrete.
 
 ## Expert Loop Plan
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 fn main() {
     gstreamer_to_topology_lib::run();
 }

--- a/src/features/workspace/SourceTextPanel.tsx
+++ b/src/features/workspace/SourceTextPanel.tsx
@@ -16,6 +16,7 @@ type SourceTextPanelProps = {
   isOpen: boolean
   selectedNode: PipelineNodeViewModel | null
   selectionRevision: number
+  onSelectNodeSource: (nodeId: string) => void
   onToggle: () => void
 }
 
@@ -76,12 +77,87 @@ function syntaxDiagnostics(diagnostics: PipelineDiagnostic[]) {
   return diagnostics.filter((diagnostic) => diagnostic.severity !== 'info')
 }
 
+type SourceNodeSpan = {
+  end: number
+  nodeId: string
+  selected: string
+  start: number
+}
+
+type SourceTextSegment = {
+  end: number
+  isHighlighted: boolean
+  nodeId?: string
+  start: number
+  text: string
+}
+
+function nodeSourceSpans(text: string, nodes: PipelineNodeViewModel[]) {
+  return nodes
+    .map((node) => {
+      const span = validSpan(text, node.sourceSpan)
+      return span
+        ? {
+            ...span,
+            nodeId: node.id,
+          }
+        : null
+    })
+    .filter((span): span is SourceNodeSpan => Boolean(span))
+    .sort((first, second) => first.start - second.start || first.end - second.end)
+}
+
+function sourceTextSegments(
+  text: string,
+  nodes: SourceNodeSpan[],
+  highlightedSpan: ReturnType<typeof validSpan>,
+) {
+  const boundaries = new Set([0, text.length])
+
+  for (const node of nodes) {
+    boundaries.add(node.start)
+    boundaries.add(node.end)
+  }
+
+  if (highlightedSpan) {
+    boundaries.add(highlightedSpan.start)
+    boundaries.add(highlightedSpan.end)
+  }
+
+  const sortedBoundaries = [...boundaries].sort((first, second) => first - second)
+  const segments: SourceTextSegment[] = []
+
+  for (let index = 0; index < sortedBoundaries.length - 1; index += 1) {
+    const start = sortedBoundaries[index]
+    const end = sortedBoundaries[index + 1]
+    if (start >= end) {
+      continue
+    }
+
+    const node = nodes.find((candidate) => start >= candidate.start && end <= candidate.end)
+    segments.push({
+      end,
+      isHighlighted: Boolean(
+        highlightedSpan
+          && start >= highlightedSpan.start
+          && end <= highlightedSpan.end,
+      ),
+      nodeId: node?.nodeId,
+      start,
+      text: text.slice(start, end),
+    })
+  }
+
+  return segments
+}
+
 function SourceTextPanel({
   document,
   focusedSource,
   isOpen,
   selectedNode,
   selectionRevision,
+  onSelectNodeSource,
   onToggle,
 }: SourceTextPanelProps) {
   const highlightRef = useRef<HTMLElement | null>(null)
@@ -89,16 +165,14 @@ function SourceTextPanel({
   const text = document.normalizedText
   const activeSpan = focusedSource?.span ?? selectedNode?.sourceSpan
   const selectedSpan = validSpan(text, activeSpan)
+  const clickableSpans = nodeSourceSpans(text, document.graph.nodes)
+  const textSegments = sourceTextSegments(text, clickableSpans, selectedSpan)
+  const highlightSegmentKey = textSegments.find((segment) => segment.isHighlighted)
+  const firstHighlightKey = highlightSegmentKey
+    ? `${highlightSegmentKey.start}-${highlightSegmentKey.end}`
+    : null
   const diagnostics = syntaxDiagnostics(document.diagnostics)
   const showHighlightFallback = Boolean((selectedNode || focusedSource) && !selectedSpan)
-
-  const highlightedText = selectedSpan
-    ? {
-        before: text.slice(0, selectedSpan.start),
-        selected: selectedSpan.selected,
-        after: text.slice(selectedSpan.end),
-      }
-    : { before: text, selected: '', after: '' }
 
   useLayoutEffect(() => {
     if (!isOpen) {
@@ -184,11 +258,45 @@ function SourceTextPanel({
 
           <pre className="source-panel__code" ref={codeScrollRef}>
             <code>
-              <span>{highlightedText.before}</span>
-              {highlightedText.selected ? (
-                <mark ref={highlightRef}>{highlightedText.selected}</mark>
-              ) : null}
-              <span>{highlightedText.after}</span>
+              {textSegments.map((segment) => {
+                const segmentKey = `${segment.start}-${segment.end}`
+                const content = segment.isHighlighted ? (
+                  <mark ref={segmentKey === firstHighlightKey ? highlightRef : undefined}>
+                    {segment.text}
+                  </mark>
+                ) : (
+                  segment.text
+                )
+
+                if (segment.nodeId) {
+                  const nodeId = segment.nodeId
+                  return (
+                    <span
+                      className={[
+                        'source-panel__node-token',
+                        segment.isHighlighted ? 'is-highlighted' : '',
+                      ].filter(Boolean).join(' ')}
+                      key={segmentKey}
+                      onClick={() => onSelectNodeSource(nodeId)}
+                      onKeyDown={(event) => {
+                        if (event.key !== 'Enter' && event.key !== ' ') {
+                          return
+                        }
+
+                        event.preventDefault()
+                        onSelectNodeSource(nodeId)
+                      }}
+                      role="button"
+                      tabIndex={0}
+                      title="캔버스에서 이 Element 선택"
+                    >
+                      {content}
+                    </span>
+                  )
+                }
+
+                return <span key={segmentKey}>{content}</span>
+              })}
             </code>
           </pre>
         </div>

--- a/src/features/workspace/WorkspaceShell.tsx
+++ b/src/features/workspace/WorkspaceShell.tsx
@@ -78,6 +78,7 @@ function WorkspaceShell({
     document.graph.nodes[0]?.id ?? null,
   )
   const [selectionRevision, setSelectionRevision] = useState(0)
+  const [canvasFocusRevision, setCanvasFocusRevision] = useState(0)
   const [activePanel, setActivePanel] = useState<WorkspacePanel | null>(null)
   const [bottomPanelHeight, setBottomPanelHeight] = useState(320)
   const [sourceFocus, setSourceFocus] = useState<SourceFocus | null>(null)
@@ -177,6 +178,7 @@ function WorkspaceShell({
     setSourceFocus(null)
     setSelectedNodeId(nodeId)
     setSelectionRevision((current) => current + 1)
+    setCanvasFocusRevision((current) => current + 1)
   }
 
   function handleShowDiagnosticSource(diagnostic: PipelineDiagnostic) {
@@ -279,6 +281,7 @@ function WorkspaceShell({
           <section className="workspace-main">
             <GraphCanvas
               document={document}
+              focusRequestRevision={canvasFocusRevision}
               selectedNodeId={selectedNodeId}
               onSelectNode={handleSelectNode}
             />

--- a/src/features/workspace/WorkspaceShell.tsx
+++ b/src/features/workspace/WorkspaceShell.tsx
@@ -173,6 +173,12 @@ function WorkspaceShell({
     setSelectionRevision((current) => current + 1)
   }
 
+  function handleSelectSourceNode(nodeId: string) {
+    setSourceFocus(null)
+    setSelectedNodeId(nodeId)
+    setSelectionRevision((current) => current + 1)
+  }
+
   function handleShowDiagnosticSource(diagnostic: PipelineDiagnostic) {
     if (!diagnostic.sourceSpan?.start && diagnostic.sourceSpan?.start !== 0) {
       return
@@ -328,6 +334,7 @@ function WorkspaceShell({
                   isOpen
                   selectedNode={selectedNode}
                   selectionRevision={selectionRevision}
+                  onSelectNodeSource={handleSelectSourceNode}
                   onToggle={() => setActivePanel(null)}
                 />
               ) : null}

--- a/src/graph/GraphCanvas.tsx
+++ b/src/graph/GraphCanvas.tsx
@@ -344,9 +344,16 @@ async function captureFullTopologyImage({
     width: exportWidth,
   }
 
-  return format === 'png'
-    ? toPng(viewport, options)
-    : toJpeg(viewport, { ...options, quality: 0.94 })
+  try {
+    stage.classList.add('is-exporting-full')
+    await nextAnimationFrame()
+
+    return format === 'png'
+      ? toPng(viewport, options)
+      : toJpeg(viewport, { ...options, quality: 0.94 })
+  } finally {
+    stage.classList.remove('is-exporting-full')
+  }
 }
 
 function GraphCanvas({

--- a/src/graph/GraphCanvas.tsx
+++ b/src/graph/GraphCanvas.tsx
@@ -11,6 +11,7 @@ import {
   type Edge,
   type NodeChange,
   type NodeMouseHandler,
+  type Node as FlowNode,
   type ReactFlowInstance,
 } from '@xyflow/react'
 import {
@@ -44,9 +45,22 @@ type ExportDraft = {
   path: string
 }
 
+type GraphBounds = {
+  height: number
+  maxX: number
+  maxY: number
+  minX: number
+  minY: number
+  width: number
+}
+
 const nodeTypes = {
   technical: TechnicalNode,
 }
+
+const EXPORT_PADDING = 180
+const MAX_EXPORT_DIMENSION = 14000
+const MAX_EXPORT_PIXELS = 42_000_000
 
 const minimapToneColors: Record<TechnicalFlowNode['data']['tone'], string> = {
   ai: '#2ec9d1',
@@ -137,7 +151,7 @@ function downloadFromBrowser(dataUrl: string, fileName: string) {
   link.remove()
 }
 
-function shouldExportNode(node: Node) {
+function shouldExportNode(node: globalThis.Node) {
   if (!(node instanceof Element)) {
     return true
   }
@@ -149,6 +163,190 @@ function shouldExportNode(node: Node) {
     node.classList.contains('react-flow__controls') ||
     node.classList.contains('react-flow__minimap')
   )
+}
+
+function nextAnimationFrame() {
+  return new Promise<void>((resolve) => {
+    window.requestAnimationFrame(() => resolve())
+  })
+}
+
+function nodeDimension(node: FlowNode) {
+  const styleWidth = typeof node.style?.width === 'number' ? node.style.width : undefined
+  const styleHeight = typeof node.style?.height === 'number' ? node.style.height : undefined
+
+  return {
+    height: styleHeight ?? node.height ?? 118,
+    width: styleWidth ?? node.width ?? 220,
+  }
+}
+
+function includeEdgeLabelBounds(bounds: GraphBounds, nodes: FlowNode[], edges: Edge[]) {
+  const nodeById = new Map(nodes.map((node) => [node.id, node]))
+
+  return edges.reduce((current, edge) => {
+    if (typeof edge.label !== 'string' || !edge.label.trim()) {
+      return current
+    }
+
+    const source = nodeById.get(edge.source)
+    const target = nodeById.get(edge.target)
+    if (!source || !target) {
+      return current
+    }
+
+    const sourceDimensions = nodeDimension(source)
+    const targetDimensions = nodeDimension(target)
+    const sourceCenter = {
+      x: source.position.x + sourceDimensions.width / 2,
+      y: source.position.y + sourceDimensions.height / 2,
+    }
+    const targetCenter = {
+      x: target.position.x + targetDimensions.width / 2,
+      y: target.position.y + targetDimensions.height / 2,
+    }
+    const labelCenter = {
+      x: (sourceCenter.x + targetCenter.x) / 2,
+      y: (sourceCenter.y + targetCenter.y) / 2,
+    }
+    const labelWidth = Math.max(120, edge.label.length * 7.6 + 56)
+    const labelHeight = 44
+    const nextMinX = Math.min(current.minX, labelCenter.x - labelWidth / 2)
+    const nextMaxX = Math.max(current.maxX, labelCenter.x + labelWidth / 2)
+    const nextMinY = Math.min(current.minY, labelCenter.y - labelHeight / 2)
+    const nextMaxY = Math.max(current.maxY, labelCenter.y + labelHeight / 2)
+
+    return {
+      ...current,
+      height: nextMaxY - nextMinY,
+      maxX: nextMaxX,
+      maxY: nextMaxY,
+      minX: nextMinX,
+      minY: nextMinY,
+      width: nextMaxX - nextMinX,
+    }
+  }, bounds)
+}
+
+function getGraphBounds(nodes: FlowNode[], edges: Edge[]): GraphBounds | null {
+  if (!nodes.length) {
+    return null
+  }
+
+  const initial = {
+    maxX: Number.NEGATIVE_INFINITY,
+    maxY: Number.NEGATIVE_INFINITY,
+    minX: Number.POSITIVE_INFINITY,
+    minY: Number.POSITIVE_INFINITY,
+  }
+
+  const bounds = nodes.reduce((current, node) => {
+    const dimensions = nodeDimension(node)
+    return {
+      maxX: Math.max(current.maxX, node.position.x + dimensions.width),
+      maxY: Math.max(current.maxY, node.position.y + dimensions.height),
+      minX: Math.min(current.minX, node.position.x),
+      minY: Math.min(current.minY, node.position.y),
+    }
+  }, initial)
+
+  return includeEdgeLabelBounds({
+    ...bounds,
+    height: bounds.maxY - bounds.minY,
+    width: bounds.maxX - bounds.minX,
+  }, nodes, edges)
+}
+
+function exportScale(width: number, height: number) {
+  const dimensionScale = Math.min(
+    MAX_EXPORT_DIMENSION / Math.max(width, 1),
+    MAX_EXPORT_DIMENSION / Math.max(height, 1),
+  )
+  const areaScale = Math.sqrt(MAX_EXPORT_PIXELS / Math.max(width * height, 1))
+
+  return Math.min(1, dimensionScale, areaScale)
+}
+
+async function captureFullTopologyImage({
+  format,
+  edges,
+  nodes,
+  stage,
+}: {
+  format: ExportFormat
+  edges: Edge[]
+  nodes: TechnicalFlowNode[]
+  stage: HTMLDivElement
+}) {
+  const viewport = stage.querySelector<HTMLElement>('.react-flow__viewport')
+  const flowRoot = stage.querySelector<HTMLElement>('.react-flow')
+  const bounds = getGraphBounds(nodes, edges)
+
+  if (!viewport || !flowRoot || !bounds) {
+    throw new Error('full topology export target is not ready')
+  }
+
+  const rawWidth = bounds.width + EXPORT_PADDING * 2
+  const rawHeight = bounds.height + EXPORT_PADDING * 2
+  const scale = exportScale(rawWidth, rawHeight)
+  const exportWidth = Math.ceil(rawWidth * scale)
+  const exportHeight = Math.ceil(rawHeight * scale)
+  const translateX = (EXPORT_PADDING - bounds.minX) * scale
+  const translateY = (EXPORT_PADDING - bounds.minY) * scale
+
+  const previousStageStyle = {
+    height: stage.style.height,
+    overflow: stage.style.overflow,
+    width: stage.style.width,
+  }
+  const previousFlowStyle = {
+    height: flowRoot.style.height,
+    width: flowRoot.style.width,
+  }
+  const previousViewportStyle = {
+    transform: viewport.style.transform,
+    transformOrigin: viewport.style.transformOrigin,
+  }
+
+  try {
+    stage.classList.add('is-exporting-full')
+    stage.style.width = `${exportWidth}px`
+    stage.style.height = `${exportHeight}px`
+    stage.style.overflow = 'visible'
+    flowRoot.style.width = `${exportWidth}px`
+    flowRoot.style.height = `${exportHeight}px`
+    viewport.style.transform = `translate(${translateX}px, ${translateY}px) scale(${scale})`
+    viewport.style.transformOrigin = '0 0'
+
+    await nextAnimationFrame()
+
+    const options = {
+      backgroundColor: '#eff6fd',
+      cacheBust: true,
+      filter: shouldExportNode,
+      height: exportHeight,
+      pixelRatio: 1,
+      style: {
+        height: `${exportHeight}px`,
+        overflow: 'visible',
+        width: `${exportWidth}px`,
+      },
+      width: exportWidth,
+    }
+
+    return format === 'png'
+      ? toPng(stage, options)
+      : toJpeg(stage, { ...options, quality: 0.94 })
+  } finally {
+    stage.classList.remove('is-exporting-full')
+    stage.style.width = previousStageStyle.width
+    stage.style.height = previousStageStyle.height
+    stage.style.overflow = previousStageStyle.overflow
+    flowRoot.style.width = previousFlowStyle.width
+    flowRoot.style.height = previousFlowStyle.height
+    viewport.style.transform = previousViewportStyle.transform
+    viewport.style.transformOrigin = previousViewportStyle.transformOrigin
+  }
 }
 
 function GraphCanvas({
@@ -170,6 +368,7 @@ function GraphCanvas({
   )
   const [exportMenuOpen, setExportMenuOpen] = useState(false)
   const [exportDraft, setExportDraft] = useState<ExportDraft | null>(null)
+  const [isExportingFullGraph, setIsExportingFullGraph] = useState(false)
   const [exportStatus, setExportStatus] = useState<ExportStatus | null>(null)
   const nodes = useMemo(
     () =>
@@ -264,21 +463,20 @@ function GraphCanvas({
     setExportMenuOpen(false)
     setExportStatus({
       tone: 'info',
-      message: `Exporting ${format.toUpperCase()}...`,
+      message: `Exporting full topology ${format.toUpperCase()}...`,
     })
 
     try {
       const fileName = `${safeFileStem(document.title)}.${format}`
-      const options = {
-        backgroundColor: '#eff6fd',
-        cacheBust: true,
-        filter: shouldExportNode,
-        pixelRatio: 2,
-      }
-      const dataUrl =
-        format === 'png'
-          ? await toPng(stage, options)
-          : await toJpeg(stage, { ...options, quality: 0.94 })
+      setIsExportingFullGraph(true)
+      await nextAnimationFrame()
+      await nextAnimationFrame()
+      const dataUrl = await captureFullTopologyImage({
+        edges,
+        format,
+        nodes,
+        stage,
+      })
 
       if (isTauriRuntime()) {
         const targetPath = explicitPath?.trim() ?? ''
@@ -317,6 +515,8 @@ function GraphCanvas({
         tone: 'error',
         message: `Export failed: ${error instanceof Error ? error.message : 'unknown error'}`,
       })
+    } finally {
+      setIsExportingFullGraph(false)
     }
   }
   const handleOpenExportDraft = async (format: ExportFormat) => {
@@ -407,7 +607,7 @@ function GraphCanvas({
           onNodeDragStop={handleNodeDragStop}
           onNodesChange={handleNodesChange}
           onPaneClick={() => onSelectNode(null)}
-          onlyRenderVisibleElements
+          onlyRenderVisibleElements={!isExportingFullGraph}
           proOptions={{ hideAttribution: true }}
         >
           <Background
@@ -508,8 +708,9 @@ function GraphCanvas({
               <span className="field-label">Export {exportDraft.format.toUpperCase()}</span>
               <h3>저장 경로 확인</h3>
               <p>
-                기본값은 Downloads 아래의 `GStreamer Topology Exports` 폴더입니다.
-                다른 위치를 원하면 전체 파일 경로를 수정해 주세요.
+                전체 토폴로지 영역을 이미지로 저장합니다. 기본값은 Downloads 아래의
+                `GStreamer Topology Exports` 폴더입니다. 다른 위치를 원하면 전체
+                파일 경로를 수정해 주세요.
               </p>
             </div>
             <label>

--- a/src/graph/GraphCanvas.tsx
+++ b/src/graph/GraphCanvas.tsx
@@ -26,6 +26,7 @@ import type { PipelineDocumentViewModel } from './types.ts'
 
 type GraphCanvasProps = {
   document: PipelineDocumentViewModel
+  focusRequestRevision?: number
   selectedNodeId: string | null
   onSelectNode: (nodeId: string | null) => void
 }
@@ -59,6 +60,7 @@ const nodeTypes = {
 }
 
 const EXPORT_PADDING = 180
+const MAX_EXPORT_ASPECT_RATIO = 6
 const MAX_EXPORT_DIMENSION = 14000
 const MAX_EXPORT_PIXELS = 42_000_000
 
@@ -267,6 +269,37 @@ function exportScale(width: number, height: number) {
   return Math.min(1, dimensionScale, areaScale)
 }
 
+function frameExportBounds(width: number, height: number) {
+  const aspectRatio = width / Math.max(height, 1)
+
+  if (aspectRatio > MAX_EXPORT_ASPECT_RATIO) {
+    const framedHeight = width / MAX_EXPORT_ASPECT_RATIO
+    return {
+      extraX: 0,
+      extraY: (framedHeight - height) / 2,
+      height: framedHeight,
+      width,
+    }
+  }
+
+  if (aspectRatio < 1 / MAX_EXPORT_ASPECT_RATIO) {
+    const framedWidth = height / MAX_EXPORT_ASPECT_RATIO
+    return {
+      extraX: (framedWidth - width) / 2,
+      extraY: 0,
+      height,
+      width: framedWidth,
+    }
+  }
+
+  return {
+    extraX: 0,
+    extraY: 0,
+    height,
+    width,
+  }
+}
+
 async function captureFullTopologyImage({
   format,
   edges,
@@ -279,78 +312,46 @@ async function captureFullTopologyImage({
   stage: HTMLDivElement
 }) {
   const viewport = stage.querySelector<HTMLElement>('.react-flow__viewport')
-  const flowRoot = stage.querySelector<HTMLElement>('.react-flow')
   const bounds = getGraphBounds(nodes, edges)
 
-  if (!viewport || !flowRoot || !bounds) {
+  if (!viewport || !bounds) {
     throw new Error('full topology export target is not ready')
   }
 
   const rawWidth = bounds.width + EXPORT_PADDING * 2
   const rawHeight = bounds.height + EXPORT_PADDING * 2
-  const scale = exportScale(rawWidth, rawHeight)
-  const exportWidth = Math.ceil(rawWidth * scale)
-  const exportHeight = Math.ceil(rawHeight * scale)
-  const translateX = (EXPORT_PADDING - bounds.minX) * scale
-  const translateY = (EXPORT_PADDING - bounds.minY) * scale
+  const framedBounds = frameExportBounds(rawWidth, rawHeight)
+  const scale = exportScale(framedBounds.width, framedBounds.height)
+  const exportWidth = Math.ceil(framedBounds.width * scale)
+  const exportHeight = Math.ceil(framedBounds.height * scale)
+  const translateX = (EXPORT_PADDING + framedBounds.extraX - bounds.minX) * scale
+  const translateY = (EXPORT_PADDING + framedBounds.extraY - bounds.minY) * scale
 
-  const previousStageStyle = {
-    height: stage.style.height,
-    overflow: stage.style.overflow,
-    width: stage.style.width,
+  await nextAnimationFrame()
+
+  const options = {
+    backgroundColor: '#eff6fd',
+    cacheBust: true,
+    filter: shouldExportNode,
+    height: exportHeight,
+    pixelRatio: 1,
+    style: {
+      height: `${exportHeight}px`,
+      transform: `translate(${translateX}px, ${translateY}px) scale(${scale})`,
+      transformOrigin: '0 0',
+      width: `${exportWidth}px`,
+    },
+    width: exportWidth,
   }
-  const previousFlowStyle = {
-    height: flowRoot.style.height,
-    width: flowRoot.style.width,
-  }
-  const previousViewportStyle = {
-    transform: viewport.style.transform,
-    transformOrigin: viewport.style.transformOrigin,
-  }
 
-  try {
-    stage.classList.add('is-exporting-full')
-    stage.style.width = `${exportWidth}px`
-    stage.style.height = `${exportHeight}px`
-    stage.style.overflow = 'visible'
-    flowRoot.style.width = `${exportWidth}px`
-    flowRoot.style.height = `${exportHeight}px`
-    viewport.style.transform = `translate(${translateX}px, ${translateY}px) scale(${scale})`
-    viewport.style.transformOrigin = '0 0'
-
-    await nextAnimationFrame()
-
-    const options = {
-      backgroundColor: '#eff6fd',
-      cacheBust: true,
-      filter: shouldExportNode,
-      height: exportHeight,
-      pixelRatio: 1,
-      style: {
-        height: `${exportHeight}px`,
-        overflow: 'visible',
-        width: `${exportWidth}px`,
-      },
-      width: exportWidth,
-    }
-
-    return format === 'png'
-      ? toPng(stage, options)
-      : toJpeg(stage, { ...options, quality: 0.94 })
-  } finally {
-    stage.classList.remove('is-exporting-full')
-    stage.style.width = previousStageStyle.width
-    stage.style.height = previousStageStyle.height
-    stage.style.overflow = previousStageStyle.overflow
-    flowRoot.style.width = previousFlowStyle.width
-    flowRoot.style.height = previousFlowStyle.height
-    viewport.style.transform = previousViewportStyle.transform
-    viewport.style.transformOrigin = previousViewportStyle.transformOrigin
-  }
+  return format === 'png'
+    ? toPng(viewport, options)
+    : toJpeg(viewport, { ...options, quality: 0.94 })
 }
 
 function GraphCanvas({
   document,
+  focusRequestRevision = 0,
   selectedNodeId,
   onSelectNode,
 }: GraphCanvasProps) {
@@ -424,7 +425,37 @@ function GraphCanvas({
       padding: 0.18,
     })
   }
-  const handleFocusSelected = () => {
+  const focusSelectedNode = (duration = 260) => {
+    if (!flow || !selectedNodeId) {
+      return
+    }
+
+    const node = nodes.find((candidate) => candidate.id === selectedNodeId)
+    if (!node) {
+      return
+    }
+
+    const width =
+      typeof node.style?.width === 'number' ? node.style.width : node.width ?? 220
+    const height =
+      typeof node.style?.height === 'number' ? node.style.height : node.height ?? 118
+    const currentZoom = flow.getZoom()
+    const nextZoom = Math.min(Math.max(currentZoom, 0.58), 1.02)
+
+    flow.setCenter(
+      node.position.x + width / 2,
+      node.position.y + height / 2,
+      {
+        duration,
+        zoom: nextZoom,
+      },
+    )
+  }
+  useEffect(() => {
+    if (!focusRequestRevision) {
+      return
+    }
+
     if (!flow || !selectedNodeId) {
       return
     }
@@ -449,6 +480,10 @@ function GraphCanvas({
         zoom: nextZoom,
       },
     )
+  }, [flow, focusRequestRevision, nodes, selectedNodeId])
+
+  const handleFocusSelected = () => {
+    focusSelectedNode(260)
   }
   const handleExport = async (format: ExportFormat, explicitPath?: string) => {
     const stage = stageRef.current

--- a/src/graph/fromBackend.ts
+++ b/src/graph/fromBackend.ts
@@ -316,7 +316,12 @@ async function layoutNodes(
       'elk.algorithm': 'layered',
       'elk.direction': 'RIGHT',
       'elk.edgeRouting': 'ORTHOGONAL',
+      'elk.spacing.edgeEdge': '18',
+      'elk.spacing.edgeNode': '42',
       'elk.spacing.nodeNode': '36',
+      'elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
+      'elk.layered.nodePlacement.strategy': 'NETWORK_SIMPLEX',
+      'elk.layered.spacing.edgeNodeBetweenLayers': '42',
       'elk.layered.spacing.nodeNodeBetweenLayers': String(layerSpacing),
     },
     children: nodes.map((node) => ({

--- a/src/graph/nodes/TechnicalNode.tsx
+++ b/src/graph/nodes/TechnicalNode.tsx
@@ -50,7 +50,6 @@ function renderPort(port: TechnicalNodePort, index: number, total: number, isSel
         position={position}
         type={type}
       />
-      <span className="technical-node__port-label">{port.label}</span>
     </span>
   )
 }

--- a/src/graph/nodes/TechnicalNode.tsx
+++ b/src/graph/nodes/TechnicalNode.tsx
@@ -1,5 +1,5 @@
 import { Handle, Position, type NodeProps } from '@xyflow/react'
-import type { TechnicalFlowNode } from '../toReactFlow.ts'
+import type { TechnicalFlowNode, TechnicalNodePort } from '../toReactFlow.ts'
 
 function nodeKindLabel(kind: string) {
   switch (kind) {
@@ -16,7 +16,49 @@ function nodeKindLabel(kind: string) {
   }
 }
 
+function portTop(index: number, total: number) {
+  if (total <= 1) {
+    return '50%'
+  }
+
+  return `${18 + (64 * index) / (total - 1)}%`
+}
+
+function renderPort(port: TechnicalNodePort, index: number, total: number, isSelected: boolean) {
+  const isSource = port.side === 'source'
+  const top = portTop(index, total)
+  const position = isSource ? Position.Right : Position.Left
+  const type = isSource ? 'source' : 'target'
+  const sideClass = isSource ? 'source' : 'sink'
+  const stateClass = port.isConnectedToSelection ? 'is-connected' : ''
+
+  return (
+    <span
+      aria-hidden
+      className={[
+        'technical-node__port',
+        `technical-node__port--${sideClass}`,
+        stateClass,
+        isSelected ? 'is-node-selected' : '',
+      ].filter(Boolean).join(' ')}
+      key={port.id}
+      style={{ top }}
+    >
+      <Handle
+        className="technical-node__handle"
+        id={port.id}
+        position={position}
+        type={type}
+      />
+      <span className="technical-node__port-label">{port.label}</span>
+    </span>
+  )
+}
+
 function TechnicalNode({ data }: NodeProps<TechnicalFlowNode>) {
+  const sourcePorts = data.ports.filter((port) => port.side === 'source')
+  const sinkPorts = data.ports.filter((port) => port.side === 'target')
+
   return (
     <div
       className={[
@@ -28,8 +70,11 @@ function TechnicalNode({ data }: NodeProps<TechnicalFlowNode>) {
         .filter(Boolean)
         .join(' ')}
     >
-      <Handle className="technical-node__handle" position={Position.Left} type="target" />
-      <span aria-hidden className="technical-node__port-dot technical-node__port-dot--sink" />
+      <span className="technical-node__port-rail technical-node__port-rail--sink">
+        {sinkPorts.map((port, index) =>
+          renderPort(port, index, sinkPorts.length, data.isSelected),
+        )}
+      </span>
       <div className="technical-node__eyebrow">
         <span>{nodeKindLabel(data.kind)}</span>
         <span className="technical-node__drag-handle" title="위치 이동">
@@ -44,8 +89,11 @@ function TechnicalNode({ data }: NodeProps<TechnicalFlowNode>) {
           <span key={tag}>{tag}</span>
         ))}
       </div>
-      <span aria-hidden className="technical-node__port-dot technical-node__port-dot--src" />
-      <Handle className="technical-node__handle" position={Position.Right} type="source" />
+      <span className="technical-node__port-rail technical-node__port-rail--source">
+        {sourcePorts.map((port, index) =>
+          renderPort(port, index, sourcePorts.length, data.isSelected),
+        )}
+      </span>
     </div>
   )
 }

--- a/src/graph/toReactFlow.ts
+++ b/src/graph/toReactFlow.ts
@@ -1,8 +1,10 @@
 import { MarkerType, type Edge, type Node } from '@xyflow/react'
 import type {
+  PipelineEdgeViewModel,
   PipelineGraphViewModel,
   PipelineNodeTone,
   PipelineNodeViewModel,
+  PipelinePortViewModel,
 } from './types.ts'
 
 type ReactFlowNodeParams = {
@@ -22,12 +24,20 @@ type TechnicalNodeData = {
   isSearchMatch: boolean
   isSelected: boolean
   label: string
+  ports: TechnicalNodePort[]
   tags: string[]
   tone: PipelineNodeTone
   warningCount: number
 }
 
 type TechnicalFlowNode = Node<TechnicalNodeData, 'technical'>
+type TechnicalNodePort = {
+  id: string
+  isConnectedToSelection: boolean
+  label: string
+  side: 'source' | 'target'
+}
+
 const DEFAULT_NODE_DIMENSIONS = {
   height: 118,
   width: 220,
@@ -45,6 +55,69 @@ function matchesSearch(node: PipelineNodeViewModel, searchValue: string) {
     .join(' ')
     .toLowerCase()
     .includes(normalizedQuery)
+}
+
+function sourceHandleId(edge: PipelineEdgeViewModel) {
+  return edge.sourcePort?.id ?? `${edge.id}:src`
+}
+
+function targetHandleId(edge: PipelineEdgeViewModel) {
+  return edge.targetPort?.id ?? `${edge.id}:sink`
+}
+
+function portLabel(port: PipelinePortViewModel | undefined, fallback: string) {
+  if (!port) {
+    return fallback
+  }
+
+  const name = port.name.trim()
+  if (!name || name === 'src' || name === 'sink') {
+    return fallback
+  }
+
+  return name
+}
+
+function buildNodePorts(
+  graph: PipelineGraphViewModel,
+  nodeId: string,
+  selectedNodeId: string | null,
+) {
+  const ports = new Map<string, TechnicalNodePort>()
+  const connectedToSelection = (edge: PipelineEdgeViewModel) =>
+    edge.sourceNodeId === selectedNodeId || edge.targetNodeId === selectedNodeId
+  const addPort = (port: TechnicalNodePort) => {
+    const existing = ports.get(port.id)
+    ports.set(port.id, {
+      ...port,
+      isConnectedToSelection:
+        port.isConnectedToSelection || Boolean(existing?.isConnectedToSelection),
+    })
+  }
+
+  graph.edges.forEach((edge, index) => {
+    if (edge.sourceNodeId === nodeId) {
+      const id = sourceHandleId(edge)
+      addPort({
+        id,
+        isConnectedToSelection: connectedToSelection(edge),
+        label: portLabel(edge.sourcePort, `SRC ${index + 1}`),
+        side: 'source',
+      })
+    }
+
+    if (edge.targetNodeId === nodeId) {
+      const id = targetHandleId(edge)
+      addPort({
+        id,
+        isConnectedToSelection: connectedToSelection(edge),
+        label: portLabel(edge.targetPort, `SINK ${index + 1}`),
+        side: 'target',
+      })
+    }
+  })
+
+  return Array.from(ports.values())
 }
 
 function toReactFlowNodes({
@@ -73,6 +146,7 @@ function toReactFlowNodes({
         isSearchMatch: matchesSearch(node, searchValue),
         isSelected: node.id === selectedNodeId,
         label: node.instanceName || node.factoryName,
+        ports: buildNodePorts(graph, node.id, selectedNodeId),
         tags: node.tags,
         tone: node.tone,
         warningCount: node.warnings.length,
@@ -88,16 +162,23 @@ function toReactFlowEdges({
   return graph.edges.map((edge) => {
     const isConnected =
       edge.sourceNodeId === selectedNodeId || edge.targetNodeId === selectedNodeId
+    const isMuted = Boolean(selectedNodeId && !isConnected)
     const label = edge.label?.trim()
 
     return {
       id: edge.id,
       source: edge.sourceNodeId,
+      sourceHandle: sourceHandleId(edge),
       target: edge.targetNodeId,
-      animated: false,
+      targetHandle: targetHandleId(edge),
+      animated: isConnected,
       ariaLabel: label ?? `${edge.sourceNodeId} to ${edge.targetNodeId}`,
-      className: isConnected ? 'technical-edge is-connected' : 'technical-edge',
-      interactionWidth: 18,
+      className: [
+        'technical-edge',
+        isConnected ? 'is-connected' : '',
+        isMuted ? 'is-muted' : '',
+      ].filter(Boolean).join(' '),
+      interactionWidth: 22,
       label,
       markerEnd: {
         color: isConnected ? 'var(--edge-active)' : 'var(--edge-muted)',
@@ -108,25 +189,31 @@ function toReactFlowEdges({
       style: {
         stroke: isConnected ? 'var(--edge-active)' : 'var(--edge-muted)',
         strokeLinecap: 'round',
-        strokeWidth: isConnected ? 2.6 : 1.6,
+        strokeOpacity: isMuted ? 0.24 : 0.82,
+        strokeWidth: isConnected ? 3 : 1.7,
       },
       labelStyle: {
         fill: isConnected ? 'var(--edge-active)' : 'var(--text-soft)',
         fontSize: label && label.length > 80 ? 12 : 11,
         fontWeight: 800,
+        opacity: isMuted ? 0.28 : 1,
       },
       labelBgStyle: {
         fill: 'rgba(247, 250, 253, 0.96)',
-        fillOpacity: 1,
+        fillOpacity: isMuted ? 0.32 : 1,
         stroke: isConnected ? 'rgba(21, 141, 255, 0.28)' : 'rgba(23, 49, 82, 0.14)',
         strokeWidth: 1,
       },
       labelBgBorderRadius: 10,
       labelBgPadding: [10, 6] as [number, number],
-      zIndex: isConnected ? 4 : 1,
+      pathOptions: {
+        borderRadius: 18,
+        offset: 28,
+      },
+      zIndex: isConnected ? 8 : 1,
     }
   })
 }
 
 export { toReactFlowEdges, toReactFlowNodes }
-export type { TechnicalFlowNode, TechnicalNodeData }
+export type { TechnicalFlowNode, TechnicalNodeData, TechnicalNodePort }

--- a/src/graph/toReactFlow.ts
+++ b/src/graph/toReactFlow.ts
@@ -58,11 +58,11 @@ function matchesSearch(node: PipelineNodeViewModel, searchValue: string) {
 }
 
 function sourceHandleId(edge: PipelineEdgeViewModel) {
-  return edge.sourcePort?.id ?? `${edge.id}:src`
+  return `${edge.id}:source:${edge.sourcePort?.id ?? 'src'}`
 }
 
 function targetHandleId(edge: PipelineEdgeViewModel) {
-  return edge.targetPort?.id ?? `${edge.id}:sink`
+  return `${edge.id}:target:${edge.targetPort?.id ?? 'sink'}`
 }
 
 function portLabel(port: PipelinePortViewModel | undefined, fallback: string) {
@@ -172,6 +172,7 @@ function toReactFlowEdges({
       target: edge.targetNodeId,
       targetHandle: targetHandleId(edge),
       animated: isConnected,
+      type: 'smoothstep',
       ariaLabel: label ?? `${edge.sourceNodeId} to ${edge.targetNodeId}`,
       className: [
         'technical-edge',
@@ -210,7 +211,7 @@ function toReactFlowEdges({
         borderRadius: 18,
         offset: 28,
       },
-      zIndex: isConnected ? 8 : 1,
+      zIndex: isConnected ? 1 : 0,
     }
   })
 }

--- a/src/styles/app-shell.css
+++ b/src/styles/app-shell.css
@@ -979,6 +979,33 @@
   outline: 1px solid rgba(76, 196, 255, 0.7);
 }
 
+.source-panel__node-token {
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: underline;
+  text-decoration-color: rgba(118, 199, 255, 0.52);
+  text-decoration-style: dotted;
+  text-underline-offset: 0.2em;
+  white-space: inherit;
+}
+
+.source-panel__node-token:hover,
+.source-panel__node-token:focus-visible {
+  border-radius: 5px;
+  background: rgba(76, 196, 255, 0.16);
+  color: #ffffff;
+  outline: none;
+}
+
+.source-panel__node-token:focus-visible {
+  box-shadow: 0 0 0 2px rgba(76, 196, 255, 0.54);
+}
+
+.source-panel__node-token.is-highlighted {
+  text-decoration-color: rgba(76, 196, 255, 0.94);
+}
+
 .diagnostics-panel__toggle {
   width: 100%;
   border: 0;

--- a/src/styles/graph.css
+++ b/src/styles/graph.css
@@ -80,6 +80,14 @@
   filter: drop-shadow(0 8px 14px rgba(21, 141, 255, 0.18));
 }
 
+.technical-edge.is-connected .react-flow__edge-textbg {
+  filter: drop-shadow(0 8px 14px rgba(21, 141, 255, 0.16));
+}
+
+.technical-edge.is-muted {
+  pointer-events: none;
+}
+
 .graph-badge {
   padding: 9px 12px;
   border-radius: 999px;
@@ -334,30 +342,112 @@
 .technical-node__handle {
   width: 10px;
   height: 10px;
-  background: rgba(22, 37, 58, 0.35);
+  background: rgba(22, 37, 58, 0.38);
   border: 2px solid rgba(255, 255, 255, 0.84);
+  transition:
+    background 140ms ease,
+    border-color 140ms ease,
+    box-shadow 140ms ease,
+    transform 140ms ease;
 }
 
-.technical-node__port-dot {
+.technical-node__port-rail {
   position: absolute;
-  top: 50%;
-  z-index: 2;
-  width: 16px;
-  height: 16px;
-  border: 3px solid rgba(247, 251, 255, 0.92);
-  border-radius: 999px;
-  background: rgba(22, 37, 58, 0.35);
-  box-shadow: 0 6px 12px rgba(15, 34, 58, 0.14);
+  top: 0;
+  bottom: 0;
+  z-index: 3;
+  width: 22px;
   pointer-events: none;
-  transform: translate(-50%, -50%);
 }
 
-.technical-node__port-dot--sink {
+.technical-node__port-rail--sink {
+  left: -12px;
+}
+
+.technical-node__port-rail--source {
+  right: -12px;
+}
+
+.technical-node__port {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border: 3px solid rgba(247, 251, 255, 0.94);
+  border-radius: 999px;
+  background: rgba(22, 37, 58, 0.36);
+  box-shadow: 0 6px 12px rgba(15, 34, 58, 0.14);
+  opacity: 0.72;
+  pointer-events: none;
+  transform: translateY(-50%);
+  transition:
+    background 140ms ease,
+    box-shadow 140ms ease,
+    opacity 140ms ease,
+    transform 140ms ease;
+}
+
+.technical-node__port--sink {
   left: 0;
 }
 
-.technical-node__port-dot--src {
-  left: 100%;
+.technical-node__port--source {
+  right: 0;
+}
+
+.technical-node__port .technical-node__handle {
+  inset: 50% auto auto 50%;
+  opacity: 0;
+  pointer-events: auto;
+  transform: translate(-50%, -50%);
+}
+
+.technical-node__port.is-connected,
+.technical-node__port.is-node-selected {
+  opacity: 1;
+}
+
+.technical-node__port.is-connected {
+  background: var(--edge-active);
+  box-shadow:
+    0 0 0 5px rgba(21, 141, 255, 0.16),
+    0 10px 18px rgba(21, 141, 255, 0.24);
+  transform: translateY(-50%) scale(1.08);
+}
+
+.technical-node__port-label {
+  position: absolute;
+  top: 50%;
+  max-width: 104px;
+  overflow: hidden;
+  padding: 4px 7px;
+  border: 1px solid rgba(21, 141, 255, 0.16);
+  border-radius: 999px;
+  background: rgba(247, 251, 255, 0.94);
+  box-shadow: 0 8px 18px rgba(15, 34, 58, 0.12);
+  color: var(--accent-primary);
+  font-size: 0.66rem;
+  font-weight: 900;
+  line-height: 1;
+  opacity: 0;
+  text-overflow: ellipsis;
+  transform: translateY(-50%) scale(0.96);
+  transition:
+    opacity 140ms ease,
+    transform 140ms ease;
+  white-space: nowrap;
+}
+
+.technical-node__port--sink .technical-node__port-label {
+  right: calc(100% + 6px);
+}
+
+.technical-node__port--source .technical-node__port-label {
+  left: calc(100% + 6px);
+}
+
+.technical-node.is-selected .technical-node__port.is-connected .technical-node__port-label {
+  opacity: 1;
+  transform: translateY(-50%) scale(1);
 }
 
 .technical-node.is-selected {

--- a/src/styles/graph.css
+++ b/src/styles/graph.css
@@ -92,6 +92,15 @@
   filter: drop-shadow(0 8px 14px rgba(21, 141, 255, 0.16));
 }
 
+.graph-stage.is-exporting-full .technical-node,
+.graph-stage.is-exporting-full .technical-node.is-selected,
+.graph-stage.is-exporting-full .technical-node__port,
+.graph-stage.is-exporting-full .react-flow__edge-path,
+.graph-stage.is-exporting-full .react-flow__edge-textbg {
+  box-shadow: none !important;
+  filter: none !important;
+}
+
 .technical-edge.is-muted {
   pointer-events: none;
 }

--- a/src/styles/graph.css
+++ b/src/styles/graph.css
@@ -76,6 +76,14 @@
   stroke-width: 2px;
 }
 
+.graph-stage .react-flow__node {
+  z-index: 8 !important;
+}
+
+.graph-stage .react-flow__edge {
+  z-index: 1 !important;
+}
+
 .technical-edge.is-connected .react-flow__edge-path {
   filter: drop-shadow(0 8px 14px rgba(21, 141, 255, 0.18));
 }
@@ -412,42 +420,6 @@
     0 0 0 5px rgba(21, 141, 255, 0.16),
     0 10px 18px rgba(21, 141, 255, 0.24);
   transform: translateY(-50%) scale(1.08);
-}
-
-.technical-node__port-label {
-  position: absolute;
-  top: 50%;
-  max-width: 104px;
-  overflow: hidden;
-  padding: 4px 7px;
-  border: 1px solid rgba(21, 141, 255, 0.16);
-  border-radius: 999px;
-  background: rgba(247, 251, 255, 0.94);
-  box-shadow: 0 8px 18px rgba(15, 34, 58, 0.12);
-  color: var(--accent-primary);
-  font-size: 0.66rem;
-  font-weight: 900;
-  line-height: 1;
-  opacity: 0;
-  text-overflow: ellipsis;
-  transform: translateY(-50%) scale(0.96);
-  transition:
-    opacity 140ms ease,
-    transform 140ms ease;
-  white-space: nowrap;
-}
-
-.technical-node__port--sink .technical-node__port-label {
-  right: calc(100% + 6px);
-}
-
-.technical-node__port--source .technical-node__port-label {
-  left: calc(100% + 6px);
-}
-
-.technical-node.is-selected .technical-node__port.is-connected .technical-node__port-label {
-  opacity: 1;
-  transform: translateY(-50%) scale(1);
 }
 
 .technical-node.is-selected {


### PR DESCRIPTION
## Sprint 07 요약

사용자 QA 완료 기준으로 Sprint 07 범위를 마무리합니다.

완료 항목:
- #25 토폴로지 PNG/JPG Export를 현재 viewport가 아니라 전체 topology graph bounds 기준으로 저장하도록 개선
- #33 Windows Release 실행 시 명령프롬프트 창이 뜨지 않도록 GUI subsystem 적용 및 Release workflow 검증 추가
- #34 Canvas Edge endpoint 분산, SRC/SINK 라벨 제거, Element 위 Edge overlay 완화
- #35 Pipeline 원문 Element 클릭 시 Canvas selection 및 자동 Focus Selected 동작 추가

후속 스프린트 후보:
- #37 Edge Crossing 최소화 라우팅 개선
- #38 Export 이미지 그림자/ghosting 제거

## 검증

통과한 내부 검증:
- `git diff --check`
- `npm run lint`
- `npm run build`
- `cd src-tauri && cargo test` : 15 passed
- `npm run tauri:build` : macOS `.app`/`.dmg` 생성 확인

사용자 QA:
- Sprint 07 Project의 #25, #33, #34, #35 모두 Done 처리 완료
- #25 핵심 기능인 전체 Pipeline Export는 확인 완료
- #34 Edge가 Element 위를 덮는 문제는 해결 확인
- #35 원문 클릭 및 자동 Focus 동작 확인 완료

## 남은 리스크

- Windows 콘솔 제거 최종 실기기 확인은 회사 Windows 11 환경에서 추가 확인 예정입니다. 문제 발생 시 신규 Issue로 등록합니다.
- Export 이미지의 ghosting 품질 개선과 Edge Crossing 최소화는 Sprint 08 후보로 분리했습니다.
