### PR TITLE
Sprint 10: RTP playback preview quality and H264 handling

### DIFF
--- a/docs/SPRINT_10_PREP.md
+++ b/docs/SPRINT_10_PREP.md
@@ -1,0 +1,146 @@
+# Sprint 10 Prep
+
+## Context
+
+Sprint 10 starts from `main` after Sprint 09 was merged.
+
+Sprint 09 delivered:
+- RTP-only Playback MVP
+- Remote/local playback process planning
+- App preview via JPEG frame polling
+- Inspector Pad Template caps visualization
+- Windows no-console command execution hardening
+- Windows/Linux release workflow verification
+
+Sprint 10 should keep the same process:
+- Use `GStreamer Topology Sprint Board` as the parent board.
+- Use the sprint-specific `Sprint 10` GitHub Project for active execution.
+- Keep work on the `sprint_10` branch.
+- Record Atlas, Forge, Loom, and Beacon outputs as Korean issue comments.
+- Do not close the sprint until user QA and Desktop Release verification are complete.
+
+## GitHub Project
+
+- Parent board: https://github.com/users/slayellow/projects/1
+- Sprint board: https://github.com/users/slayellow/projects/8
+- Sprint branch: `sprint_10`
+
+## Initial Scope
+
+### #48 Remote RTP Playback Failure With H264 Vendor Pipeline
+
+Issue:
+- https://github.com/slayellow/GStreamer-Topology/issues/48
+
+Priority:
+- P1
+
+Type:
+- Bug / QA follow-up
+
+Observed user QA:
+- Windows 11 App can connect to the remote target and detect the remote
+  GStreamer version.
+- Remote playback works for a simple RAW RTP sender:
+
+```text
+videotestsrc is-live=true pattern=smpte ! video/x-raw,format=RGB,width=640,height=360,framerate=30/1 ! videoconvert ! rtpvrawpay pt=96 ! application/x-rtp,media=(string)video,clock-rate=(int)90000,encoding-name=(string)RAW,sampling=(string)RGB,depth=(string)8,width=(string)640,height=(string)360,colorimetry=(string)SMPTE240M,payload=(int)96,a-framerate=(string)30 ! udpsink host=192.168.100.112 port=15000
+```
+
+- Remote playback fails for a Qualcomm camera/H264 RTP sender:
+
+```text
+qtiqmmfsrc camera=0 name=eocam0 ! video/x-raw(memory:GBM),format=NV12,framerate=30/1,width=1920,height=1080 !
+qtic2venc name=eo_venc control-rate=2 idr-interval=60 target-bitrate=3000000 !
+h264parse config-interval=-1 ! tee name=eoenc ! rtph264pay mtu=1350 config-interval=1 name=pay0 pt=96 ! udpsink host=192.168.100.112 port=15000
+```
+
+Likely investigation areas:
+- H264 RTP caps are not rich enough for the generated local preview receiver.
+- Local PC may not have the required H264 decoder plugin, such as `avdec_h264`.
+- Remote process may start but local preview may not receive frames.
+- `udpsink host` may need to match the Windows PC IP reachable from OE-Linux.
+- Current diagnostics may collapse distinct failures into a generic playback error.
+
+Acceptance criteria:
+- The app distinguishes remote launch failure, local decoder/plugin failure,
+  frame timeout, and host/IP mismatch as separate user-facing states where
+  possible.
+- H264 RTP preview works when the local environment has the required GStreamer
+  plugins.
+- If H264 preview cannot run, the user sees a concrete next action.
+- Stop/close cleans up local and remote playback processes.
+
+Verification:
+- `git diff --check`
+- `npm run lint`
+- `npm run build`
+- `cd src-tauri && cargo test`
+- Remote Windows/OE-Linux user QA with both pipelines from issue #48.
+
+### #46 RTP Playback Preview Quality Improvement Spike
+
+Issue:
+- https://github.com/slayellow/GStreamer-Topology/issues/46
+
+Priority:
+- P2
+
+Type:
+- Technical spike / performance improvement
+
+Goal:
+- Decide whether the current JPEG frame polling bridge should be replaced or
+  improved.
+
+Candidate approaches:
+- `MJPEG local HTTP`
+- Rust GStreamer `appsink`
+- WebRTC
+
+Constraints:
+- Must preserve Windows/Linux/macOS app direction.
+- Must not require executing arbitrary PLD text through a shell.
+- Must not leave orphan processes or local servers after Stop/Close.
+- Should not expand Sprint 10 beyond the #48 P1 failure unless time allows.
+
+Acceptance criteria:
+- Compare candidates by implementation complexity, preview smoothness, CPU cost,
+  packaging risk, and Stop/cleanup behavior.
+- Validate at least one candidate with a small command-level or prototype proof.
+- Recommend one implementation path for a future sprint.
+
+## Initial Sprint Order
+
+1. Reproduce or reason through #48 from the current backend playback plan.
+2. Improve diagnostics and H264 RTP receiver generation.
+3. Verify local RAW RTP and H264 RTP preview paths with fixtures or command-level tests.
+4. Hand #48 to user QA before deep work on #46.
+5. Run #46 as a bounded spike only after #48 has a usable fix or clear blocker.
+
+## Expert Loop Expectations
+
+For each implementation slice:
+- Atlas defines the smallest testable outcome.
+- Forge implements only the approved slice.
+- Loom reviews user-visible state, error messaging, and preview layout.
+- Beacon verifies happy path, failure path, and regression coverage.
+
+Post results back to the related GitHub issue in Korean before requesting user QA.
+
+## Known Risks
+
+- The local Windows environment may not include H264 decoder plugins by default.
+- OE-Linux device-specific plugins are not reproducible on the local Mac.
+- RTP H264 caps may require SPS/PPS or payload details not present in the static PLD.
+- Network routing between OE-Linux and the Windows PC may be the real failure even if both GStreamer pipelines are valid.
+
+## Handoff
+
+Sprint 10 is prepared but implementation has not started.
+
+Ready state:
+- `Sprint 10` GitHub Project exists and is linked to `GStreamer-Topology`.
+- Issues #48 and #46 are in both the parent board and Sprint 10 board as `Todo`.
+- Sprint labels and role labels are applied.
+- Local branch `sprint_10` is created from updated `main`.

--- a/docs/SPRINT_10_PREP.md
+++ b/docs/SPRINT_10_PREP.md
@@ -144,3 +144,43 @@ Ready state:
 - Issues #48 and #46 are in both the parent board and Sprint 10 board as `Todo`.
 - Sprint labels and role labels are applied.
 - Local branch `sprint_10` is created from updated `main`.
+
+## Implementation Update - 2026-05-18
+
+Status:
+- Issues #48 and #46 were moved to `In Progress` on both the parent board and
+  the Sprint 10 board.
+- Atlas, Forge, Loom, and Beacon review outputs were summarized as Korean issue
+  comments.
+
+Implemented for #48:
+- Sender RTP detection now infers caps from payloader elements such as
+  `rtph264pay pt=96` when explicit `application/x-rtp` caps are missing.
+- H264/H265 preview chains use `decodebin` after depay/parse instead of a fixed
+  `avdec_h264` or `avdec_h265` element.
+- Local playback process stdout/stderr is written to a temporary log so early
+  plugin/decoder failures can be surfaced in the Playback status message.
+
+Implemented for #46:
+- App preview now exposes a local MJPEG HTTP stream URL per preview stream and
+  renders that URL in the WebView.
+- The existing GStreamer JPEG frame generation path remains in place, but the
+  frontend no longer needs to refresh the visible image via fast base64 polling
+  once a stream URL is available.
+- Preview frame generation was raised from `12fps / jpeg quality 75 / max-files
+  16` to `24fps / jpeg quality 82 / max-files 32`.
+- Playback cards now show `LIVE`, `WAITING`, or `READY` badges plus basic stream
+  metadata.
+
+Internal verification:
+- `git diff --check`
+- `npm run lint`
+- `npm run build`
+- `cd src-tauri && cargo test` (`34 passed`)
+
+Still unverified:
+- Actual Windows 11 + OE-Linux H264 RTP preview behavior.
+- Whether the user's Windows environment allows the local `127.0.0.1` MJPEG
+  preview URL without firewall/security interference.
+- Visual smoothness of the MJPEG bridge under real one-stream and two-stream
+  playback.

--- a/src-tauri/src/commands/pipeline.rs
+++ b/src-tauri/src/commands/pipeline.rs
@@ -1,11 +1,14 @@
 use std::env;
 use std::fs;
-use std::io::Read;
-use std::net::TcpStream;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
-use std::sync::Mutex;
-use std::thread;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use base64::{engine::general_purpose, Engine as _};
@@ -31,12 +34,14 @@ struct PlaybackSession {
     frame_sources: Vec<PlaybackFrameSource>,
     pid: u32,
     preview_dir: Option<PathBuf>,
+    preview_server: Option<MjpegPreviewServer>,
     processes: Vec<PlaybackProcessHandle>,
 }
 
 struct PlaybackProcess {
     child: Child,
     command: String,
+    log_path: Option<PathBuf>,
     pid: u32,
 }
 
@@ -52,9 +57,17 @@ enum PlaybackProcessHandle {
     Remote(RemotePlaybackProcess),
 }
 
+#[derive(Clone)]
 struct PlaybackFrameSource {
     folder: PathBuf,
     stream_id: String,
+    stream_url: Option<String>,
+}
+
+struct MjpegPreviewServer {
+    base_url: String,
+    handle: Option<JoinHandle<()>>,
+    stop: Arc<AtomicBool>,
 }
 
 impl Drop for PlaybackSession {
@@ -62,8 +75,20 @@ impl Drop for PlaybackSession {
         for process in &mut self.processes {
             let _ = kill_playback_process(process);
         }
+        if let Some(server) = self.preview_server.take() {
+            drop(server);
+        }
         if let Some(preview_dir) = &self.preview_dir {
             let _ = fs::remove_dir_all(preview_dir);
+        }
+    }
+}
+
+impl Drop for MjpegPreviewServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
         }
     }
 }
@@ -1013,6 +1038,17 @@ pub fn start_local_playback(
         };
     }
     let frame_sources = playback_frame_sources(&plan.streams, &preview_dir);
+    let (frame_sources, mut preview_server) = if frame_sources.is_empty() {
+        (frame_sources, None)
+    } else {
+        match start_mjpeg_preview_server(&frame_sources) {
+            Ok(server) => {
+                let frame_sources = with_mjpeg_stream_urls(&frame_sources, &server.base_url);
+                (frame_sources, Some(server))
+            }
+            Err(_) => (frame_sources, None),
+        }
+    };
     let command_text = plan
         .launch_steps
         .iter()
@@ -1051,6 +1087,9 @@ pub fn start_local_playback(
                 for process in &mut processes {
                     let _ = kill_playback_process(process);
                 }
+                if let Some(server) = preview_server.take() {
+                    drop(server);
+                }
                 let _ = fs::remove_dir_all(&preview_dir);
                 return PlaybackStatusResponse {
                     state: PlaybackProcessState::Error,
@@ -1069,6 +1108,7 @@ pub fn start_local_playback(
             frame_sources,
             pid,
             preview_dir: Some(preview_dir),
+            preview_server,
             processes,
         });
         PlaybackStatusResponse {
@@ -1078,6 +1118,9 @@ pub fn start_local_playback(
             message: Some("Playback Pipeline을 실행했습니다.".to_string()),
         }
     } else {
+        if let Some(server) = preview_server.take() {
+            drop(server);
+        }
         let _ = fs::remove_dir_all(preview_dir);
         PlaybackStatusResponse {
             state: PlaybackProcessState::Error,
@@ -1176,12 +1219,24 @@ fn spawn_local_playback_process(
     pipeline: &str,
 ) -> Result<PlaybackProcessHandle, String> {
     let args = gst_launch_args(pipeline)?;
+    let log_path = env::temp_dir().join(format!(
+        "gst-topology-playback-local-{}-{}.log",
+        std::process::id(),
+        chrono_like_timestamp()
+    ));
+    let log_file = fs::File::create(&log_path).ok();
     let mut command = gstreamer_command(command_path);
     command
         .args(&args)
         .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .stdout(
+            log_file
+                .as_ref()
+                .and_then(|file| file.try_clone().ok())
+                .map(Stdio::from)
+                .unwrap_or_else(Stdio::null),
+        )
+        .stderr(log_file.map(Stdio::from).unwrap_or_else(Stdio::null));
     let child = command
         .spawn()
         .map_err(|error| format!("Local gst-launch 실행 실패: {error}"))?;
@@ -1190,6 +1245,7 @@ fn spawn_local_playback_process(
     Ok(PlaybackProcessHandle::Local(PlaybackProcess {
         child,
         command: format!("{} {}", command_path.display(), args.join(" ")),
+        log_path: Some(log_path),
         pid,
     }))
 }
@@ -1273,14 +1329,22 @@ fn playback_process_status(process: &mut PlaybackProcessHandle) -> Result<Option
     match process {
         PlaybackProcessHandle::Local(process) => match process.child.try_wait() {
             Ok(None) => Ok(None),
-            Ok(Some(status)) => Ok(Some(format!(
-                "Local PID {} 종료{}",
-                process.pid,
-                status
-                    .code()
-                    .map(|code| format!(" (exit {code})"))
-                    .unwrap_or_default()
-            ))),
+            Ok(Some(status)) => {
+                let log_tail = read_local_playback_log(process).unwrap_or_default();
+                Ok(Some(format!(
+                    "Local PID {} 종료{}{}",
+                    process.pid,
+                    status
+                        .code()
+                        .map(|code| format!(" (exit {code})"))
+                        .unwrap_or_default(),
+                    if log_tail.trim().is_empty() {
+                        String::new()
+                    } else {
+                        format!(": {}", summarize_playback_failure_hint(log_tail.trim()))
+                    }
+                )))
+            }
             Err(error) => Err(error.to_string()),
         },
         PlaybackProcessHandle::Remote(process) => {
@@ -1297,7 +1361,7 @@ fn playback_process_status(process: &mut PlaybackProcessHandle) -> Result<Option
                     if log_tail.trim().is_empty() {
                         String::new()
                     } else {
-                        format!(": {}", log_tail.trim())
+                        format!(": {}", summarize_playback_failure_hint(log_tail.trim()))
                     }
                 )))
             }
@@ -1308,10 +1372,14 @@ fn playback_process_status(process: &mut PlaybackProcessHandle) -> Result<Option
 fn kill_playback_process(process: &mut PlaybackProcessHandle) -> Result<(), String> {
     match process {
         PlaybackProcessHandle::Local(process) => match process.child.try_wait() {
-            Ok(Some(_)) => Ok(()),
+            Ok(Some(_)) => {
+                remove_local_playback_log(process);
+                Ok(())
+            }
             Ok(None) => {
                 process.child.kill().map_err(|error| error.to_string())?;
                 process.child.wait().map_err(|error| error.to_string())?;
+                remove_local_playback_log(process);
                 Ok(())
             }
             Err(error) => Err(error.to_string()),
@@ -1331,6 +1399,55 @@ fn kill_playback_process(process: &mut PlaybackProcessHandle) -> Result<(), Stri
                 Err(output.stderr.if_empty("Remote Playback process 종료 실패."))
             }
         }
+    }
+}
+
+fn read_local_playback_log(process: &PlaybackProcess) -> Result<String, String> {
+    let Some(log_path) = &process.log_path else {
+        return Ok(String::new());
+    };
+    let text = fs::read_to_string(log_path).map_err(|error| error.to_string())?;
+    let mut lines = text
+        .lines()
+        .rev()
+        .take(20)
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    lines.reverse();
+
+    Ok(lines.join("\n"))
+}
+
+fn summarize_playback_failure_hint(log_tail: &str) -> String {
+    let lower = log_tail.to_ascii_lowercase();
+    let compact = log_tail
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" | ");
+    let compact = if compact.len() > 700 {
+        format!("{}...", &compact[..700])
+    } else {
+        compact
+    };
+
+    if lower.contains("no element")
+        || lower.contains("missing plugin")
+        || lower.contains("could not link")
+        || lower.contains("erroneous pipeline")
+    {
+        return format!(
+            "로컬 GStreamer plugin/decoder 문제 가능성이 있습니다. H264 Preview는 rtph264depay, h264parse, decodebin이 사용할 H264 decoder, jpegenc가 필요합니다. 원본 로그: {compact}"
+        );
+    }
+
+    compact
+}
+
+fn remove_local_playback_log(process: &PlaybackProcess) {
+    if let Some(log_path) = &process.log_path {
+        let _ = fs::remove_file(log_path);
     }
 }
 
@@ -1449,6 +1566,7 @@ pub fn get_local_playback_frame(
                 stream_id,
                 available: false,
                 data_url: None,
+                stream_url: None,
                 updated_at_millis: None,
                 diagnostic: Some("Playback 상태 잠금을 가져오지 못했습니다.".to_string()),
             };
@@ -1460,6 +1578,7 @@ pub fn get_local_playback_frame(
             stream_id,
             available: false,
             data_url: None,
+            stream_url: None,
             updated_at_millis: None,
             diagnostic: Some("Playback Pipeline이 실행 중이 아닙니다.".to_string()),
         };
@@ -1474,6 +1593,7 @@ pub fn get_local_playback_frame(
             stream_id,
             available: false,
             data_url: None,
+            stream_url: None,
             updated_at_millis: None,
             diagnostic: Some("이 스트림에는 App preview frame source가 없습니다.".to_string()),
         };
@@ -1546,10 +1666,10 @@ fn rtp_playback_chain(
         return "rtpjpegdepay ! jpegdec ! videoconvert ! autovideosink".to_string();
     }
     if rtp_caps_has_encoding(&caps_lower, "h264") {
-        return "rtph264depay ! h264parse ! avdec_h264 ! videoconvert ! autovideosink".to_string();
+        return "rtph264depay ! h264parse ! decodebin ! videoconvert ! autovideosink".to_string();
     }
     if rtp_caps_has_encoding(&caps_lower, "h265") || rtp_caps_has_encoding(&caps_lower, "hevc") {
-        return "rtph265depay ! h265parse ! avdec_h265 ! videoconvert ! autovideosink".to_string();
+        return "rtph265depay ! h265parse ! decodebin ! videoconvert ! autovideosink".to_string();
     }
     if rtp_caps_has_encoding(&caps_lower, "opus") {
         return "rtpopusdepay ! opusdec ! audioconvert ! audioresample ! autoaudiosink".to_string();
@@ -1624,22 +1744,22 @@ fn rtp_frame_preview_chain(
 
     if rtp_caps_has_encoding(&caps_lower, "raw") {
         return format!(
-            "rtpvrawdepay ! videoconvert ! videorate ! video/x-raw,framerate=12/1 ! jpegenc quality=75 ! {sink_chain}"
+            "rtpvrawdepay ! videoconvert ! videorate ! video/x-raw,framerate=24/1 ! jpegenc quality=82 ! {sink_chain}"
         );
     }
     if rtp_caps_has_encoding(&caps_lower, "jpeg") {
         return format!(
-            "rtpjpegdepay ! jpegdec ! videoconvert ! videorate ! video/x-raw,framerate=12/1 ! jpegenc quality=75 ! {sink_chain}"
+            "rtpjpegdepay ! jpegdec ! videoconvert ! videorate ! video/x-raw,framerate=24/1 ! jpegenc quality=82 ! {sink_chain}"
         );
     }
     if rtp_caps_has_encoding(&caps_lower, "h264") {
         return format!(
-            "rtph264depay ! h264parse ! avdec_h264 ! videoconvert ! videorate ! video/x-raw,framerate=12/1 ! jpegenc quality=75 ! {sink_chain}"
+            "rtph264depay ! h264parse ! decodebin ! videoconvert ! videorate ! video/x-raw,framerate=24/1 ! jpegenc quality=82 ! {sink_chain}"
         );
     }
     if rtp_caps_has_encoding(&caps_lower, "h265") || rtp_caps_has_encoding(&caps_lower, "hevc") {
         return format!(
-            "rtph265depay ! h265parse ! avdec_h265 ! videoconvert ! videorate ! video/x-raw,framerate=12/1 ! jpegenc quality=75 ! {sink_chain}"
+            "rtph265depay ! h265parse ! decodebin ! videoconvert ! videorate ! video/x-raw,framerate=24/1 ! jpegenc quality=82 ! {sink_chain}"
         );
     }
 
@@ -1647,7 +1767,7 @@ fn rtp_frame_preview_chain(
         PlaybackMediaKind::Audio => "decodebin ! autoaudiosink".to_string(),
         PlaybackMediaKind::Unknown | PlaybackMediaKind::Video => {
             format!(
-                "decodebin ! videoconvert ! videorate ! video/x-raw,framerate=12/1 ! jpegenc quality=75 ! {sink_chain}"
+                "decodebin ! videoconvert ! videorate ! video/x-raw,framerate=24/1 ! jpegenc quality=82 ! {sink_chain}"
             )
         }
     }
@@ -1660,7 +1780,7 @@ fn rtp_caps_has_encoding(caps_lower: &str, encoding: &str) -> bool {
 
 fn frame_sink_chain(frame_location: &str) -> String {
     format!(
-        "multifilesink location=\"{}\" max-files=16",
+        "multifilesink location=\"{}\" max-files=32",
         escape_gst_value(frame_location)
     )
 }
@@ -1855,25 +1975,134 @@ fn playback_frame_sources(
         .map(|stream| PlaybackFrameSource {
             folder: preview_dir.to_path_buf(),
             stream_id: stream.id.clone(),
+            stream_url: None,
         })
         .collect()
 }
 
-fn latest_playback_frame(frame_source: &PlaybackFrameSource) -> PlaybackFrameResponse {
-    let prefix = safe_stream_file_prefix(&frame_source.stream_id);
-    let entries = match fs::read_dir(&frame_source.folder) {
-        Ok(entries) => entries,
-        Err(error) => {
-            return PlaybackFrameResponse {
-                stream_id: frame_source.stream_id.clone(),
-                available: false,
-                data_url: None,
-                updated_at_millis: None,
-                diagnostic: Some(format!("Preview frame 폴더를 읽지 못했습니다: {error}")),
-            };
+fn with_mjpeg_stream_urls(
+    frame_sources: &[PlaybackFrameSource],
+    base_url: &str,
+) -> Vec<PlaybackFrameSource> {
+    frame_sources
+        .iter()
+        .map(|source| PlaybackFrameSource {
+            folder: source.folder.clone(),
+            stream_id: source.stream_id.clone(),
+            stream_url: Some(format!("{base_url}/{}.mjpeg", source.stream_id)),
+        })
+        .collect()
+}
+
+fn start_mjpeg_preview_server(
+    frame_sources: &[PlaybackFrameSource],
+) -> Result<MjpegPreviewServer, String> {
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .map_err(|error| format!("Preview MJPEG server bind 실패: {error}"))?;
+    listener
+        .set_nonblocking(true)
+        .map_err(|error| format!("Preview MJPEG server nonblocking 설정 실패: {error}"))?;
+    let port = listener
+        .local_addr()
+        .map_err(|error| format!("Preview MJPEG server 주소 확인 실패: {error}"))?
+        .port();
+    let stop = Arc::new(AtomicBool::new(false));
+    let thread_stop = Arc::clone(&stop);
+    let sources = frame_sources.to_vec();
+    let handle = thread::spawn(move || {
+        while !thread_stop.load(Ordering::Relaxed) {
+            match listener.accept() {
+                Ok((stream, _)) => {
+                    let client_sources = sources.clone();
+                    let client_stop = Arc::clone(&thread_stop);
+                    thread::spawn(move || {
+                        serve_mjpeg_client(stream, client_sources, client_stop);
+                    });
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(25));
+                }
+                Err(_) => break,
+            }
         }
+    });
+
+    Ok(MjpegPreviewServer {
+        base_url: format!("http://127.0.0.1:{port}"),
+        handle: Some(handle),
+        stop,
+    })
+}
+
+fn serve_mjpeg_client(
+    mut stream: TcpStream,
+    frame_sources: Vec<PlaybackFrameSource>,
+    stop: Arc<AtomicBool>,
+) {
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+    let mut buffer = [0u8; 1024];
+    let read_len = stream.read(&mut buffer).unwrap_or(0);
+    let request = String::from_utf8_lossy(&buffer[..read_len]);
+    let stream_id = request
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|path| path.trim_start_matches('/').strip_suffix(".mjpeg"))
+        .map(ToOwned::to_owned);
+    let Some(stream_id) = stream_id else {
+        let _ = stream.write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n");
+        return;
+    };
+    let Some(frame_source) = frame_sources
+        .into_iter()
+        .find(|source| source.stream_id == stream_id)
+    else {
+        let _ = stream.write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n");
+        return;
     };
 
+    if stream
+        .write_all(
+            b"HTTP/1.1 200 OK\r\nContent-Type: multipart/x-mixed-replace; boundary=frame\r\nCache-Control: no-cache, no-store, must-revalidate\r\nPragma: no-cache\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\n",
+        )
+        .is_err()
+    {
+        return;
+    }
+
+    let mut last_sent: Option<SystemTime> = None;
+    while !stop.load(Ordering::Relaxed) {
+        match latest_preview_frame_path(&frame_source) {
+            Ok(Some((path, modified))) if last_sent.is_none_or(|previous| modified > previous) => {
+                match fs::read(path) {
+                    Ok(bytes) => {
+                        let header = format!(
+                            "--frame\r\nContent-Type: image/jpeg\r\nContent-Length: {}\r\n\r\n",
+                            bytes.len()
+                        );
+                        if stream.write_all(header.as_bytes()).is_err()
+                            || stream.write_all(&bytes).is_err()
+                            || stream.write_all(b"\r\n").is_err()
+                            || stream.flush().is_err()
+                        {
+                            return;
+                        }
+                        last_sent = Some(modified);
+                    }
+                    Err(_) => thread::sleep(Duration::from_millis(40)),
+                }
+            }
+            _ => thread::sleep(Duration::from_millis(40)),
+        }
+    }
+}
+
+fn latest_preview_frame_path(
+    frame_source: &PlaybackFrameSource,
+) -> Result<Option<(PathBuf, SystemTime)>, String> {
+    let prefix = safe_stream_file_prefix(&frame_source.stream_id);
+    let entries = fs::read_dir(&frame_source.folder)
+        .map_err(|error| format!("Preview frame 폴더를 읽지 못했습니다: {error}"))?;
     let mut latest: Option<(PathBuf, SystemTime)> = None;
     for entry in entries.flatten() {
         let path = entry.path();
@@ -1897,15 +2126,52 @@ fn latest_playback_frame(frame_source: &PlaybackFrameSource) -> PlaybackFrameRes
         }
     }
 
+    Ok(latest)
+}
+
+fn latest_playback_frame(frame_source: &PlaybackFrameSource) -> PlaybackFrameResponse {
+    let latest = match latest_preview_frame_path(frame_source) {
+        Ok(latest) => latest,
+        Err(error) => {
+            return PlaybackFrameResponse {
+                stream_id: frame_source.stream_id.clone(),
+                available: false,
+                data_url: None,
+                stream_url: frame_source.stream_url.clone(),
+                updated_at_millis: None,
+                diagnostic: Some(error),
+            };
+        }
+    };
+
     let Some((path, modified)) = latest else {
         return PlaybackFrameResponse {
             stream_id: frame_source.stream_id.clone(),
-            available: false,
+            available: frame_source.stream_url.is_some(),
             data_url: None,
+            stream_url: frame_source.stream_url.clone(),
             updated_at_millis: None,
-            diagnostic: Some("아직 수신된 preview frame이 없습니다.".to_string()),
+            diagnostic: Some(
+                "Playback 프로세스는 실행 중입니다. 첫 preview frame을 기다리는 중입니다."
+                    .to_string(),
+            ),
         };
     };
+
+    let updated_at_millis = modified
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|duration| u64::try_from(duration.as_millis()).ok());
+    if frame_source.stream_url.is_some() {
+        return PlaybackFrameResponse {
+            stream_id: frame_source.stream_id.clone(),
+            available: true,
+            data_url: None,
+            stream_url: frame_source.stream_url.clone(),
+            updated_at_millis,
+            diagnostic: None,
+        };
+    }
 
     let bytes = match fs::read(&path) {
         Ok(bytes) => bytes,
@@ -1914,15 +2180,12 @@ fn latest_playback_frame(frame_source: &PlaybackFrameSource) -> PlaybackFrameRes
                 stream_id: frame_source.stream_id.clone(),
                 available: false,
                 data_url: None,
+                stream_url: None,
                 updated_at_millis: None,
                 diagnostic: Some(format!("Preview frame을 읽지 못했습니다: {error}")),
             };
         }
     };
-    let updated_at_millis = modified
-        .duration_since(UNIX_EPOCH)
-        .ok()
-        .and_then(|duration| u64::try_from(duration.as_millis()).ok());
 
     PlaybackFrameResponse {
         stream_id: frame_source.stream_id.clone(),
@@ -1931,6 +2194,7 @@ fn latest_playback_frame(frame_source: &PlaybackFrameSource) -> PlaybackFrameRes
             "data:image/jpeg;base64,{}",
             general_purpose::STANDARD.encode(bytes)
         )),
+        stream_url: None,
         updated_at_millis,
         diagnostic: None,
     }
@@ -2044,7 +2308,9 @@ fn extract_rtp_candidates(raw_text: &str) -> Vec<RtpCandidate> {
             }
         }
 
-        let Some(caps) = find_nearest_rtp_caps_before(&tokens, index) else {
+        let Some(caps) = find_nearest_rtp_caps_before(&tokens, index)
+            .or_else(|| infer_rtp_caps_from_payloader_before(&tokens, index))
+        else {
             index = cursor.saturating_add(1);
             continue;
         };
@@ -2077,6 +2343,74 @@ fn find_nearest_rtp_caps_before(tokens: &[String], index: usize) -> Option<Strin
         if token.contains("application/x-rtp") {
             return Some(token.trim_matches('"').to_string());
         }
+    }
+
+    None
+}
+
+fn infer_rtp_caps_from_payloader_before(tokens: &[String], index: usize) -> Option<String> {
+    let mut cursor = index;
+    while cursor > 0 {
+        cursor -= 1;
+        let token = &tokens[cursor];
+        if token == "udpsrc" || token == "udpsink" || token == "rtspsrc" {
+            return None;
+        }
+        let factory = token.trim();
+        let payload = find_payloader_payload(tokens, cursor, index).unwrap_or_else(|| "96".into());
+        let caps = match factory {
+            "rtph264pay" => {
+                format!(
+                    "application/x-rtp,media=video,encoding-name=H264,payload={payload},clock-rate=90000"
+                )
+            }
+            "rtph265pay" | "rtphevcpay" => {
+                format!(
+                    "application/x-rtp,media=video,encoding-name=H265,payload={payload},clock-rate=90000"
+                )
+            }
+            "rtpjpegpay" => {
+                format!(
+                    "application/x-rtp,media=video,encoding-name=JPEG,payload={payload},clock-rate=90000"
+                )
+            }
+            "rtpvrawpay" => {
+                format!(
+                    "application/x-rtp,media=video,encoding-name=RAW,payload={payload},clock-rate=90000"
+                )
+            }
+            "rtpopuspay" => {
+                format!(
+                    "application/x-rtp,media=audio,encoding-name=OPUS,payload={payload},clock-rate=48000"
+                )
+            }
+            "rtpmp4gpay" => {
+                format!(
+                    "application/x-rtp,media=audio,encoding-name=MPEG4-GENERIC,payload={payload},clock-rate=48000"
+                )
+            }
+            _ => continue,
+        };
+
+        return Some(caps);
+    }
+
+    None
+}
+
+fn find_payloader_payload(
+    tokens: &[String],
+    payloader_index: usize,
+    sink_index: usize,
+) -> Option<String> {
+    let mut cursor = payloader_index + 1;
+    while cursor < sink_index && tokens[cursor] != "!" {
+        if let Some(value) = parse_token_value(&tokens[cursor], "pt")
+            .or_else(|| parse_token_value(&tokens[cursor], "payload"))
+        {
+            return Some(value);
+        }
+        cursor += 1;
     }
 
     None
@@ -3017,6 +3351,36 @@ Element Properties:
         assert!(!streams[0]
             .playback_pipeline
             .contains("! decodebin ! autovideosink"));
+    }
+
+    #[test]
+    fn playback_detection_infers_h264_caps_from_sender_payloader() {
+        let raw_text = "qtiqmmfsrc camera=0 name=eocam0 ! video/x-raw(memory:GBM),format=NV12,framerate=30/1,width=1920,height=1080 ! qtic2venc name=eo_venc control-rate=2 idr-interval=60 target-bitrate=3000000 ! h264parse config-interval=-1 ! tee name=eoenc ! rtph264pay mtu=1350 config-interval=1 name=pay0 pt=96 ! udpsink host=192.168.100.112 port=15000";
+        let streams = detect_playback_streams(raw_text);
+
+        assert_eq!(streams.len(), 1);
+        assert_eq!(streams[0].direction, PlaybackDirection::Sender);
+        assert_eq!(streams[0].media_kind, PlaybackMediaKind::Video);
+        assert_eq!(streams[0].port, Some(15000));
+        assert!(streams[0]
+            .caps
+            .as_deref()
+            .is_some_and(|caps| caps.contains("encoding-name=(string)H264")));
+        assert!(streams[0]
+            .caps
+            .as_deref()
+            .is_some_and(|caps| caps.contains("payload=(int)96")));
+
+        let plan = build_playback_plan(raw_text, None, Some(Path::new("/tmp/gst-preview")));
+        assert!(plan.playable);
+        assert!(plan
+            .counterpart_pipeline
+            .as_deref()
+            .is_some_and(|pipeline| pipeline.contains("rtph264depay ! h264parse ! decodebin")));
+        assert!(plan
+            .counterpart_pipeline
+            .as_deref()
+            .is_some_and(|pipeline| pipeline.contains("framerate=24/1")));
     }
 
     #[test]

--- a/src-tauri/src/models/pipeline.rs
+++ b/src-tauri/src/models/pipeline.rs
@@ -310,6 +310,7 @@ pub struct PlaybackFrameResponse {
     pub stream_id: String,
     pub available: bool,
     pub data_url: Option<String>,
+    pub stream_url: Option<String>,
     pub updated_at_millis: Option<u64>,
     pub diagnostic: Option<String>,
 }

--- a/src/app/backend.ts
+++ b/src/app/backend.ts
@@ -175,6 +175,7 @@ export type PlaybackFrameResponse = {
   stream_id: string
   available: boolean
   data_url?: string | null
+  stream_url?: string | null
   updated_at_millis?: number | null
   diagnostic?: string | null
 }

--- a/src/features/playback/PlaybackPanel.tsx
+++ b/src/features/playback/PlaybackPanel.tsx
@@ -78,6 +78,45 @@ function mediaKindLabel(stream: PlaybackStream) {
   }
 }
 
+function streamEncodingLabel(stream: PlaybackStream) {
+  const match = stream.caps?.match(/encoding-name=(?:\(string\))?([^,\s]+)/i)
+  return match?.[1] ? match[1].toUpperCase() : 'RTP'
+}
+
+function streamEndpointLabel(stream: PlaybackStream) {
+  const host = stream.host ?? 'local'
+  return stream.port ? `${host}:${stream.port}` : host
+}
+
+function frameImageSource(frame?: PlaybackFrameResponse) {
+  return frame?.stream_url ?? frame?.data_url ?? undefined
+}
+
+function frameStateLabel(frame: PlaybackFrameResponse | undefined, isPlaying: boolean) {
+  if (frame?.stream_url && frame.updated_at_millis) {
+    return 'LIVE'
+  }
+  if (frame?.data_url) {
+    return 'FRAME'
+  }
+  if (isPlaying) {
+    return 'WAITING'
+  }
+
+  return 'READY'
+}
+
+function frameStateTone(frame: PlaybackFrameResponse | undefined, isPlaying: boolean) {
+  if ((frame?.stream_url && frame.updated_at_millis) || frame?.data_url) {
+    return 'live'
+  }
+  if (isPlaying) {
+    return 'waiting'
+  }
+
+  return 'idle'
+}
+
 function PlaybackPanel({
   disabledReason,
   documentTitle,
@@ -102,7 +141,25 @@ function PlaybackPanel({
   const expandedStream = expandedStreamId
     ? prepareResult?.streams.find((stream) => stream.id === expandedStreamId)
     : undefined
-  const statusToneName = statusTone(status, prepareResult)
+  const expandedImageSource = frameImageSource(expandedFrame)
+  const previewStreams =
+    prepareResult?.streams.filter(
+      (stream) => stream.media_kind === 'video' || stream.media_kind === 'unknown',
+    ) ?? []
+  const isLivePreview =
+    isPlaying &&
+    previewStreams.length > 0 &&
+    previewStreams.every((stream) => Boolean(frames[stream.id]?.updated_at_millis))
+  const statusToneName =
+    isPlaying && previewStreams.length > 0 && !isLivePreview
+      ? 'info'
+      : statusTone(status, prepareResult)
+  const statusText =
+    isPlaying && previewStreams.length > 0
+      ? isLivePreview
+        ? 'Live preview'
+        : '프레임 대기'
+      : statusLabel(status, prepareResult)
   const helperMessage =
     disabledReason ??
     message ??
@@ -126,7 +183,7 @@ function PlaybackPanel({
           </div>
           <div className="playback-window__header-actions">
             <span className={`card-chip playback-status playback-status--${statusToneName}`}>
-              {statusLabel(status, prepareResult)}
+              {statusText}
             </span>
             <IconButton icon="close" label="Playback 창 닫기" onClick={onClose} />
           </div>
@@ -158,34 +215,52 @@ function PlaybackPanel({
 
         <section className="playback-window__preview" aria-label="Media Preview">
           {prepareResult?.streams.length ? (
-            prepareResult.streams.map((stream, index) => (
-              <article className="playback-stream-card" key={stream.id}>
-                <div className="playback-stream-card__screen">
-                  {frames[stream.id]?.data_url ? (
-                    <button
-                      className="playback-stream-card__frame-button"
-                      onClick={() => setExpandedStreamId(stream.id)}
-                      type="button"
+            prepareResult.streams.map((stream, index) => {
+              const frame = frames[stream.id]
+              const imageSource = frameImageSource(frame)
+
+              return (
+                <article className="playback-stream-card" key={stream.id}>
+                  <div className="playback-stream-card__screen">
+                    <span
+                      className={`playback-stream-card__live-badge playback-stream-card__live-badge--${frameStateTone(frame, isPlaying)}`}
                     >
-                      <img
-                        alt={`Stream ${index + 1} preview`}
-                        className="playback-stream-card__frame"
-                        src={frames[stream.id].data_url ?? undefined}
-                      />
-                      <span>크게 보기</span>
-                    </button>
-                  ) : (
-                    <div className="playback-stream-card__placeholder">
-                      <span>Stream {index + 1}</span>
-                      <strong>{mediaKindLabel(stream)}</strong>
-                      {isPlaying ? (
-                        <small>{frames[stream.id]?.diagnostic ?? 'preview frame 수신 대기 중'}</small>
-                      ) : null}
-                    </div>
-                  )}
-                </div>
-              </article>
-            ))
+                      {frameStateLabel(frame, isPlaying)}
+                    </span>
+                    {imageSource ? (
+                      <button
+                        className="playback-stream-card__frame-button"
+                        onClick={() => setExpandedStreamId(stream.id)}
+                        type="button"
+                      >
+                        <img
+                          alt={`Stream ${index + 1} preview`}
+                          className="playback-stream-card__frame"
+                          src={imageSource}
+                        />
+                        <span>크게 보기</span>
+                      </button>
+                    ) : (
+                      <div className="playback-stream-card__placeholder">
+                        <span>Stream {index + 1}</span>
+                        <strong>{mediaKindLabel(stream)}</strong>
+                        {isPlaying ? (
+                          <small>
+                            {frames[stream.id]?.diagnostic ?? 'preview frame 수신 대기 중'}
+                          </small>
+                        ) : null}
+                      </div>
+                    )}
+                  </div>
+                  <div className="playback-stream-card__meta">
+                    <span>{`Stream ${index + 1}`}</span>
+                    <span>{directionLabel(stream)}</span>
+                    <span>{streamEncodingLabel(stream)}</span>
+                    <span>{streamEndpointLabel(stream)}</span>
+                  </div>
+                </article>
+              )
+            })
           ) : (
             <div className="playback-window__empty">
               <span className="card-chip muted-chip">Preview</span>
@@ -194,7 +269,7 @@ function PlaybackPanel({
           )}
         </section>
       </div>
-      {expandedFrame?.data_url && expandedStream ? (
+      {expandedImageSource && expandedStream ? (
         <div className="playback-preview-modal" role="dialog" aria-modal="true">
           <section className="playback-preview-modal__surface panel">
             <header>
@@ -208,7 +283,7 @@ function PlaybackPanel({
                 onClick={() => setExpandedStreamId(null)}
               />
             </header>
-            <img alt={`${expandedStream.id} expanded preview`} src={expandedFrame.data_url} />
+            <img alt={`${expandedStream.id} expanded preview`} src={expandedImageSource} />
           </section>
         </div>
       ) : null}

--- a/src/features/workspace/WorkspaceShell.tsx
+++ b/src/features/workspace/WorkspaceShell.tsx
@@ -303,7 +303,14 @@ function WorkspaceShell({
     }
 
     let isCancelled = false
+    let isPollingSlowly = false
+    let requestInFlight = false
+    let timerId: number | undefined
     const loadFrames = () => {
+      if (requestInFlight) {
+        return
+      }
+      requestInFlight = true
       Promise.all(previewStreams.map((stream) => getLocalPlaybackFrame(stream.id)))
         .then((frames) => {
           if (isCancelled) {
@@ -319,18 +326,34 @@ function WorkspaceShell({
               current.frames,
             ),
           }))
+          if (
+            !isPollingSlowly &&
+            frames.length === previewStreams.length &&
+            frames.every((frame) => Boolean(frame.stream_url))
+          ) {
+            isPollingSlowly = true
+            if (timerId) {
+              window.clearInterval(timerId)
+            }
+            timerId = window.setInterval(loadFrames, 1000)
+          }
         })
         .catch((error) => {
           console.error(error)
         })
+        .finally(() => {
+          requestInFlight = false
+        })
     }
 
     loadFrames()
-    const timerId = window.setInterval(loadFrames, 120)
+    timerId = window.setInterval(loadFrames, 120)
 
     return () => {
       isCancelled = true
-      window.clearInterval(timerId)
+      if (timerId) {
+        window.clearInterval(timerId)
+      }
     }
   }, [isPlaybackOpen, playbackState.prepareResult, playbackState.status.state])
 

--- a/src/styles/app-shell.css
+++ b/src/styles/app-shell.css
@@ -1315,6 +1315,8 @@
 .playback-stream-card {
   min-height: 0;
   display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  gap: 10px;
   padding: 14px;
   border: 1px solid var(--stroke-soft);
   border-radius: 22px;
@@ -1329,6 +1331,7 @@
 }
 
 .playback-stream-card__screen {
+  position: relative;
   min-height: 0;
   display: grid;
   place-items: center;
@@ -1338,6 +1341,46 @@
     radial-gradient(circle at 30% 20%, rgba(76, 196, 255, 0.18), transparent 30%),
     linear-gradient(135deg, #071426, #13233a);
   color: rgba(255, 255, 255, 0.72);
+}
+
+.playback-stream-card__live-badge {
+  position: absolute;
+  left: 12px;
+  top: 12px;
+  z-index: 2;
+  border-radius: 999px;
+  padding: 5px 9px;
+  background: rgba(255, 255, 255, 0.82);
+  color: #4d6078;
+  font-size: 0.68rem;
+  font-weight: 1000;
+  letter-spacing: 0.08em;
+  box-shadow: 0 10px 24px rgba(7, 20, 38, 0.12);
+}
+
+.playback-stream-card__live-badge--live {
+  background: rgba(31, 220, 143, 0.9);
+  color: #07311e;
+}
+
+.playback-stream-card__live-badge--waiting {
+  background: rgba(255, 202, 86, 0.92);
+  color: #513500;
+}
+
+.playback-stream-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.playback-stream-card__meta span {
+  border-radius: 999px;
+  padding: 6px 9px;
+  background: rgba(226, 235, 245, 0.78);
+  color: #52677f;
+  font-size: 0.74rem;
+  font-weight: 900;
 }
 
 .playback-stream-card__placeholder {


### PR DESCRIPTION
## Summary

Sprint 10 closes the RTP Playback follow-up items for preview quality and remote H264 sender handling.

- Improve RTP preview transport by exposing per-stream local MJPEG URLs instead of relying on fast base64 image refresh for visible playback.
- Raise preview generation from 12 fps / JPEG quality 75 to 24 fps / JPEG quality 82.
- Add LIVE / WAITING / READY preview badges and stream metadata in the Playback panel.
- Infer RTP caps from payloader elements such as `rtph264pay pt=96` when sender PLDs do not include explicit `application/x-rtp` caps.
- Use `decodebin` for H264/H265 preview chains instead of fixed `avdec_h264` / `avdec_h265` elements.
- Capture local gst-launch stdout/stderr to temporary logs so early plugin/decoder failures surface as actionable Playback messages.

## Related Issues

- Closes #46
- Closes #48

## Validation

- `git diff --check`
- `npm run lint`
- `npm run build`
- `cd src-tauri && cargo test` (`34 passed`)

## Notes

- Actual Windows 11 + OE-Linux H264 RTP preview remains field-verification dependent.
- macOS signed release artifacts are still intentionally excluded until Apple Developer ID notarization is available.
